### PR TITLE
Make the Imposter's stop point to original's

### DIFF
--- a/py_trees/src/py_trees/composites.py
+++ b/py_trees/src/py_trees/composites.py
@@ -283,7 +283,7 @@ class Selector(Composite):
     def stop(self, new_status=Status.INVALID):
         """
         Stopping a selector requires setting the current child to none. Note that it
-        is important to implement this here intead of terminate, so users are free
+        is important to implement this here instead of terminate, so users are free
         to subclass this easily with their own terminate and not have to remember
         that they need to call this function manually.
         """

--- a/py_trees/src/py_trees/meta.py
+++ b/py_trees/src/py_trees/meta.py
@@ -108,6 +108,7 @@ def imposter(cls):
             self.setup = self.original.setup
             self.initialise = self.original.initialise
             self.terminate = self.original.terminate
+            self.stop = self.original.stop
             # id is important to match for composites...the children must relate to the correct parent id
             self.id = self.original.id
 


### PR DESCRIPTION
Without this, the `stop()` is the `Behaviours.stop()` which doesn't terminate it's children.


