### PR TITLE
Imposter's own tick 

### DIFF
--- a/py_trees/CMakeLists.txt
+++ b/py_trees/CMakeLists.txt
@@ -26,7 +26,6 @@ catkin_install_python(
     PROGRAMS
         scripts/demo_behaviour
         scripts/demo_dot_graphs
-        scripts/demo_imposter
         scripts/demo_tree
         scripts/blackboard_watcher
     DESTINATION

--- a/py_trees/CMakeLists.txt
+++ b/py_trees/CMakeLists.txt
@@ -26,6 +26,7 @@ catkin_install_python(
     PROGRAMS
         scripts/demo_behaviour
         scripts/demo_dot_graphs
+        scripts/demo_imposter
         scripts/demo_tree
         scripts/blackboard_watcher
     DESTINATION
@@ -41,4 +42,3 @@ install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 if (CATKIN_ENABLE_TESTING)
   add_subdirectory(tests)
 endif()
-

--- a/py_trees/src/py_trees/behaviour.py
+++ b/py_trees/src/py_trees/behaviour.py
@@ -129,7 +129,7 @@ class Behaviour(object):
 
         :return: the behaviour's current :py:class:`Status <py_trees.common.Status>`
         """
-        self.logger.debug("  %s [Behaviour.update()]" % self.name)
+        self.logger.debug("  %s [%s.update()]" % (self.name, self.__class__.__name__))
         return Status.INVALID
 
     ############################################
@@ -224,7 +224,7 @@ class Behaviour(object):
 
         :return py_trees.Behaviour: a reference to itself
         """
-        self.logger.debug("  %s [Behaviour.tick()]" % self.name)
+        self.logger.debug("  %s [%s.tick()]" % (self.name, self.__class__.__name__))
         if self.status != Status.RUNNING:
             self.initialise()
         # don't set self.status yet, terminate() may need to check what the current state is first
@@ -260,7 +260,7 @@ class Behaviour(object):
 
         .. warning:: Do not override this method, use :py:meth:`terminate` instead.
         """
-        self.logger.debug("  %s [Behaviour.stop()][%s->%s]" % (self.name, self.status, new_status))
+        self.logger.debug("  %s [%s.stop()][%s->%s]" % (self.name, self.__class__.__name__, self.status, new_status))
         self.terminate(new_status)
         self.status = new_status
         self.iterator = self.tick()

--- a/py_trees/src/py_trees/composites.py
+++ b/py_trees/src/py_trees/composites.py
@@ -84,7 +84,7 @@ class Composite(Behaviour):
         it to truly stop (INVALID). We only really want to update everything below if we are in
         the second use case. The first use case will subehaviours will have already handled themselves.
         """
-        self.logger.debug("  %s [Composite.stop()][%s->%s]" % (self.name, self.status, new_status))
+        self.logger.debug("  %s [%s.stop()][%s->%s]" % (self.name, self.__class__.__name__, self.status, new_status))
         if new_status == Status.INVALID:
             for child in self.children:
                 child.stop(new_status)

--- a/py_trees/src/py_trees/meta.py
+++ b/py_trees/src/py_trees/meta.py
@@ -112,6 +112,25 @@ def imposter(cls):
             # id is important to match for composites...the children must relate to the correct parent id
             self.id = self.original.id
 
+        def tick(self):
+            """
+            This function overrides Behaviour.tick() and work the same way
+            except it would not call initialise and stop methods on original
+            and let the original's update handle it's state.
+
+            :return py_trees.Behaviour: a reference to itself
+            """
+            self.logger.debug("  %s [Imposter.tick()]" % self.name)
+
+            # initialise() and terminate() for the original behaviour
+            # will be called from inside the update()
+            new_status = self.update()
+            if new_status not in list(common.Status):
+                self.logger.error("A behaviour returned an invalid status, setting to INVALID [%s][%s]" % (new_status, self.name))
+                new_status = common.Status.INVALID
+            self.status = new_status
+            yield self
+
         def update(self):
             """
             This is the usual method where extra functionality
@@ -306,6 +325,7 @@ def running_is_failure(cls):
         return wrapped
 
     RunningIsFailure = imposter(cls)
+    setattr(RunningIsFailure, "__name__", running_is_failure.__name__)
     setattr(RunningIsFailure, "update", _update(RunningIsFailure.update))
     return RunningIsFailure
 
@@ -343,6 +363,7 @@ def running_is_success(cls):
         return wrapped
 
     RunningIsSuccess = imposter(cls)
+    setattr(RunningIsSuccess, "__name__", running_is_success.__name__)
     setattr(RunningIsSuccess, "update", _update(RunningIsSuccess.update))
     return RunningIsSuccess
 
@@ -380,6 +401,7 @@ def failure_is_success(cls):
         return wrapped
 
     FailureIsSuccess = imposter(cls)
+    setattr(FailureIsSuccess, "__name__", failure_is_success.__name__)
     setattr(FailureIsSuccess, "update", _update(FailureIsSuccess.update))
     return FailureIsSuccess
 
@@ -417,6 +439,7 @@ def failure_is_running(cls):
         return wrapped
 
     FailureIsRunning = imposter(cls)
+    setattr(FailureIsRunning, "__name__", failure_is_running.__name__)
     setattr(FailureIsRunning, "update", _update(FailureIsRunning.update))
     return FailureIsRunning
 
@@ -454,6 +477,7 @@ def success_is_failure(cls):
         return wrapped
 
     SuccessIsFailure = imposter(cls)
+    setattr(SuccessIsFailure, "__name__", success_is_failure.__name__)
     setattr(SuccessIsFailure, "update", _update(SuccessIsFailure.update))
     return SuccessIsFailure
 
@@ -491,5 +515,6 @@ def success_is_running(cls):
         return wrapped
 
     SuccessIsRunning = imposter(cls)
+    setattr(SuccessIsRunning, "__name__", success_is_running.__name__)
     setattr(SuccessIsRunning, "update", _update(SuccessIsRunning.update))
     return SuccessIsRunning

--- a/py_trees/src/py_trees/meta.py
+++ b/py_trees/src/py_trees/meta.py
@@ -124,6 +124,10 @@ def imposter(cls):
             This function overrides Behaviour.tick() and work the same way
             except it would not call initialise and stop methods on original
             and let the original's update handle it's state.
+            
+            There is some analysis explaining the need for this override in
+            
+                https://github.com/stonier/py_trees_suite/issues/32
 
             :return py_trees.Behaviour: a reference to itself
             """

--- a/py_trees/src/py_trees/meta.py
+++ b/py_trees/src/py_trees/meta.py
@@ -92,10 +92,17 @@ def imposter(cls):
             not linked in the usual fashion.
             """
             if 'name' in kwargs:
+                kwargs['name'] = str(kwargs['name'])
                 name = kwargs['name']
+                kwargs['name'] = "_" + kwargs['name']
                 new_args = args
             else:
-                new_args = list(args)
+                # if the list is empty, give it a placeholder name
+                if not args:
+                    new_args = ["Imposter"]
+                else:
+                    new_args = list(args)
+                    new_args[0] = str(new_args[0])
                 name = new_args[0]
                 new_args[0] = "_" + name
                 new_args = tuple(new_args)
@@ -120,7 +127,7 @@ def imposter(cls):
 
             :return py_trees.Behaviour: a reference to itself
             """
-            self.logger.debug("  %s [Imposter.tick()]" % self.name)
+            self.logger.debug("  %s [%s.tick()]" % (self.name, self.__class__.__name__))
 
             # initialise() and terminate() for the original behaviour
             # will be called from inside the update()


### PR DESCRIPTION
imposter overrides Behaviour.tick() to avoid duplicate init/terminate calls

also adds specific class names for imposter behaviours for exact name display in rqt_py_trees on hover