### PR TITLE
[meta] Adds add_child() method to meta for child adoption from origin…

### DIFF
--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -150,9 +150,7 @@ class Composite(Behaviour):
             children ([:class:`~py_trees.behaviour.Behaviour`]): list of children to add
         """
         for child in children:
-            assert isinstance(child, Behaviour), "children must be behaviours, but you passed in %s" % type(child)
-            self.children.append(child)
-            child.parent = self
+            self.add_child(child)
 
     def remove_child(self, child):
         """

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -132,7 +132,7 @@ class Composite(Behaviour):
         Adds a child.
 
         Args:
-            child (:class:`~py_trees.behaviour.Behaviour`): child to delete
+            child (:class:`~py_trees.behaviour.Behaviour`): child to add
 
         Returns:
             uuid.UUID: unique id of the child

--- a/py_trees/meta.py
+++ b/py_trees/meta.py
@@ -173,6 +173,15 @@ def create_imposter(cls):
             # id is important to match for composites...the children must relate to the correct parent id
             self.id = self.original.id
 
+            if isinstance(self.original, composites.Composite):
+                # monkeypatch add_child
+                def add_child(child):
+                    assert isinstance(child, behaviour.Behaviour), "children must be behaviours, but you passed in %s" % type(child)
+                    self.children.append(child)
+                    child.parent = self
+                    return child.id
+                self.original.add_child = add_child
+
         def tip(self):
             """
             This function overrides :meth:`~py_trees.behaviour.Behaviour.tip`
@@ -187,34 +196,6 @@ def create_imposter(cls):
                 return self.original.tip()
             else:
                 return super(Imposter, self).tip()
-
-        def add_child(self, child):
-            """
-            Adds a child. This function overrides :meth:`~py_trees.composites.Composite.add_child`
-            with additional adoption of child from the original composite.
-            If the original is :class:`~py_trees.behaviour.Behaviour`,
-            this would raise exception as it would do usually.
-
-            Args:
-                child (:class:`~py_trees.behaviour.Behaviour`): child to add
-
-            Returns:
-                uuid.UUID: unique id of the child
-            """
-            self.original.add_child(child)
-            # meta adopts the child from original
-            child.parent = self
-            return child.id
-
-        def add_children(self, children):
-            """
-            Append a list of children to the current list.
-
-            Args:
-                children ([:class:`~py_trees.behaviour.Behaviour`]): list of children to add
-            """
-            for child in children:
-                self.add_child(child)
 
         def tick(self):
             """

--- a/py_trees/meta.py
+++ b/py_trees/meta.py
@@ -175,7 +175,7 @@ def create_imposter(cls):
 
         def tip(self):
             """
-            This function overrides :meth:`~py_trees.behaviour.Behaviour.tick`
+            This function overrides :meth:`~py_trees.behaviour.Behaviour.tip`
             and provides a fused capability depending on whether the original
             behaviour is a composite or not. If it is composite, it relies on
             the composite's return value, else it uses it's own.
@@ -187,6 +187,34 @@ def create_imposter(cls):
                 return self.original.tip()
             else:
                 return super(Imposter, self).tip()
+
+        def add_child(self, child):
+            """
+            Adds a child. This function overrides :meth:`~py_trees.composites.Composite.add_child`
+            with additional adoption of child from the original composite.
+            If the original is :class:`~py_trees.behaviour.Behaviour`,
+            this would raise exception as it would do usually.
+
+            Args:
+                child (:class:`~py_trees.behaviour.Behaviour`): child to add
+
+            Returns:
+                uuid.UUID: unique id of the child
+            """
+            self.original.add_child(child)
+            # meta adopts the child from original
+            child.parent = self
+            return child.id
+
+        def add_children(self, children):
+            """
+            Append a list of children to the current list.
+
+            Args:
+                children ([:class:`~py_trees.behaviour.Behaviour`]): list of children to add
+            """
+            for child in children:
+                self.add_child(child)
 
         def tick(self):
             """

--- a/tests/test_imposter.py
+++ b/tests/test_imposter.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+# License: BSD
+#   https://raw.githubusercontent.com/stonier/py_trees/devel/LICENSE
+#
+##############################################################################
+# Imports
+##############################################################################
+
+# enable some python3 compatibility options:
+# (unicode_literals not compatible with python2 uuid module)
+from __future__ import absolute_import, print_function
+
+import py_trees
+import py_trees.console as console
+
+##############################################################################
+# Logging Level
+##############################################################################
+
+py_trees.logging.level = py_trees.logging.Level.DEBUG
+logger = py_trees.logging.Logger("Nosetest")
+
+
+##############################################################################
+# Helpers
+##############################################################################
+
+def create_impostered_composite():
+    return py_trees.meta.failure_is_running(py_trees.composites.Sequence)("Impostered Composite")
+
+
+def create_impostered_behaviour():
+    return py_trees.meta.success_is_failure(py_trees.behaviours.Success)("Impostered Behaviour")
+
+
+def has_child_with_name(parent, child_name):
+    return child_name if child_name in [c.name for c in parent.children] else None
+
+
+##############################################################################
+# Tests
+##############################################################################
+
+def test_imposter_has_add_child_method():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Test Imposter has add_child_method" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    tuples = []
+    tuples.append((create_impostered_behaviour(), False))
+    tuples.append((create_impostered_composite(), True))
+    for b, asserted_result in tuples:
+        print("%s has add_child: %s [%s]" % (b.name, hasattr(b, 'add_child'), asserted_result))
+        assert(hasattr(b, 'add_child') == asserted_result)
+
+
+def test_parent_chain():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Test Parent Chain" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    root = py_trees.composites.Parallel("Root")
+    sequence_failure_is_running = create_impostered_composite()
+    success_is_failure = create_impostered_behaviour()
+
+    sequence_failure_is_running.add_child(success_is_failure)
+    root.add_child(sequence_failure_is_running)
+
+    tuples = []
+    tuples.append((success_is_failure, sequence_failure_is_running.name))
+    tuples.append((sequence_failure_is_running, root.name))
+    for child, asserted_result in tuples:
+        print("%s's parent: %s [%s]" % (child.name, child.parent.name, asserted_result))
+        assert(child.parent.name == asserted_result)
+
+
+def test_parent_chain_with_add_children():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Test Parent Chain with add_children" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    root = py_trees.composites.Parallel("Root")
+    sequence_failure_is_running = create_impostered_composite()
+    success_is_failure = create_impostered_behaviour()
+
+    sequence_failure_is_running.add_children([success_is_failure])
+    root.add_children([sequence_failure_is_running])
+
+    tuples = []
+    tuples.append((success_is_failure, sequence_failure_is_running.name))
+    tuples.append((sequence_failure_is_running, root.name))
+    for child, asserted_result in tuples:
+        print("%s's parent: %s [%s]" % (child.name, child.parent.name, asserted_result))
+        assert(child.parent.name == asserted_result)
+
+
+def test_child_chain():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Test Child Chain" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    root = py_trees.composites.Parallel("Root")
+    sequence_failure_is_running = create_impostered_composite()
+    success_is_failure = create_impostered_behaviour()
+
+    sequence_failure_is_running.add_child(success_is_failure)
+    root.add_child(sequence_failure_is_running)
+
+    tuples = []
+    tuples.append((root, sequence_failure_is_running.name))
+    tuples.append((sequence_failure_is_running, success_is_failure.name))
+    for parent, asserted_result in tuples:
+        print("%s's child: %s [%s]" % (parent.name, has_child_with_name(parent, asserted_result), asserted_result))
+        assert(has_child_with_name(parent, asserted_result) == asserted_result)


### PR DESCRIPTION
…al composite.

This is for the issue #56. The actual issue lies in the family tree if there exists Imposter (black sheep). The `children` of imposter-composites will have `original` as their parent and `original` has no parent link to the tree above.

for instance:
```

root = <Parallel>
imp_seq = <Imposter><Sequence>
idle = <Success>

root.add_child(imp_seq)
imp_seq.add_child(idle)

----------------------
idle.parent -> Sequence
idle.parent.parent -> None (*broken link between meta and it's original*)
imp_seq.parent -> Parallel
```

