### PR TITLE
Oneshots no longer reset when priority interrupted

### DIFF
--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -474,7 +474,7 @@ class Sequence(Composite):
         """
         self.logger.debug("%s.tick()" % self.__class__.__name__)
         if self.status != Status.RUNNING:
-            self.logger.debug("%s.tick() [resetting]" % self.__class__.__name__)
+            self.logger.debug("%s.tick() [!RUNNING->resetting child index]" % self.__class__.__name__)
             # sequence specific handling
             self.current_index = 0
             for child in self.children:

--- a/py_trees/meta.py
+++ b/py_trees/meta.py
@@ -154,8 +154,6 @@ def create_imposter(cls):
             self.blackbox_level = self.original.blackbox_level
             self.children = self.original.children
             self.setup = self.original.setup
-            self.terminate = self.original.terminate
-            self.stop = self.original.stop
             # id is important to match for composites...the children must relate to the correct parent id
             self.id = self.original.id
 
@@ -220,6 +218,17 @@ def create_imposter(cls):
             """
             return self.original.status
 
+        def terminate(self, new_status):
+            """
+            Imposter's custom implementation of termination that is called when
+            higher priority interrupts occur. Note that stop/terminate are not called
+            in the usual sequence of a tick, since that would double up on stop
+            calls to the underlying original.
+            """
+            self.logger.debug("%s.terminate()[%s]" % (self.__class__.__name__, new_status))
+            self.original.stop(new_status)
+            self.status = self.original.status
+
         def __getattr__(self, name):
             """
             So we can pull extra attributes in the original above and beyond the behaviour attributes.
@@ -228,9 +237,9 @@ def create_imposter(cls):
 
     return Imposter
 
-# ##############################################################################
-# # Timeout
-# ##############################################################################
+##############################################################################
+# Timeout
+##############################################################################
 
 
 def timeout(cls, duration):
@@ -309,6 +318,63 @@ def timeout(cls, duration):
     setattr(Timeout, "terminate", _timeout_terminate(Timeout.terminate))
     return Timeout
 
+##############################################################################
+# Oneshot
+##############################################################################
+
+
+def oneshot(cls):
+    def _oneshot_init(func):
+        @functools.wraps(func)
+        def wrapped(self, *args, **kwargs):
+            func(self, *args, **kwargs)
+            self.final_status = None
+        return wrapped
+
+    def _oneshot_update(func):
+        @functools.wraps(func)
+        def wrapped(self, *args, **kwargs):
+            self.logger.debug("OneShot.wrapped_update()")
+            if self.final_status:
+                return self.final_status
+            else:
+                if self.original.status in (common.Status.FAILURE, common.Status.SUCCESS):
+                    self.final_status = self.original.status
+                return self.original.status
+        return wrapped
+
+    def _oneshot_tick(func):
+        @functools.wraps(func)
+        def wrapped(self, *args, **kwargs):
+            if self.final_status:
+                self.status = self.final_status
+                self.logger.debug("OneShot.wrapped_tick()[rebounding]")
+                yield self
+            else:
+                self.logger.debug("OneShot.wrapped_tick()")
+                for behaviour in func(self):
+                    yield behaviour
+        return wrapped
+
+    def _oneshot_terminate(func):
+        @functools.wraps(func)
+        def wrapped(self, new_status):
+            self.logger.debug("OneShot.wrapped_terminate()[{}]".format(new_status))
+            # handle only the interrupt/reset case
+            if new_status == common.Status.INVALID:
+                if self.final_status:
+                    self.status = new_status
+                else:
+                    self.original.stop(new_status)
+                    self.status = self.original.status
+        return wrapped
+
+    OneShot = create_imposter(cls)
+    setattr(OneShot, "__init__", _oneshot_init(OneShot.__init__))
+    setattr(OneShot, "update", _oneshot_update(OneShot.update))
+    setattr(OneShot, "tick", _oneshot_tick(OneShot.tick))
+    setattr(OneShot, "terminate", _oneshot_terminate(OneShot.terminate))
+    return OneShot
 
 ##############################################################################
 # Inverter
@@ -356,58 +422,6 @@ def inverter(cls):
     Inverter = create_imposter(cls)
     setattr(Inverter, "update", _update(Inverter.update))
     return Inverter
-
-##############################################################################
-# Oneshot
-##############################################################################
-
-
-def _oneshot_tick(func):
-    """
-    Replace the default tick with one which runs the original function only if
-    the oneshot variable is unset, yielding the unmodified object otherwise.
-    """
-    @functools.wraps(func)
-    def wrapped(self, *args, **kwargs):
-        if self.status == common.Status.FAILURE or self.status == common.Status.SUCCESS:
-            # if returned success/fail at any point, don't update or re-init
-            yield self
-        else:
-            # otherwise, run the tick as normal yield from in python 3.3
-            for child in func(self, *args, **kwargs):
-                yield child
-    return wrapped
-
-
-def oneshot(cls):
-    """
-    A decorator that ensures the given behaviour run only until it returns
-    success or failure. For all subsequent re-entries to the behaviour, it
-    will continue returning the same status.
-
-    Args:
-        cls (:class:`~py_trees.behaviour.Behaviour`): an existing behaviour class type
-
-    Returns:
-        :class:`~py_trees.behaviour.Behaviour`: the modified behaviour class
-
-    Examples:
-        .. code-block:: python
-
-           @oneshot
-           class DoOrDie(GimmeASecondChance)
-               pass
-
-        or
-
-        .. code-block:: python
-
-           do_or_die = gimme_a_second_chance(GimmeASecondChance)("Do or Die")
-    """
-    class OneShot(cls):
-        pass
-    setattr(OneShot, "tick", _oneshot_tick(OneShot.tick))
-    return OneShot
 
 #############################
 # RunningIsFailure

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -27,27 +27,78 @@ logger = py_trees.logging.Logger("Nosetest")
 ##############################################################################
 
 
-def tick_tree(root):
+def tick_tree(root, oneshot, from_tick, to_tick):
     """
     Tick the tree and return the node count on the last tick.
-    @returns count : the number of nodes traversed on the last tick
+
+    Args:
+        root (:class:`~py_trees.behaviour.Behaviour`): root of the tree
+        oneshot (:class:`~py_trees.behaviour.Behaviour`): oneshot behaviour to track
+        from_tick (:obj:`int`) : starting tick number
+        to_tick (:obj:`int`) : final tick number (inclusive)
+
+    Returns:
+        count : the number of nodes traversed on the last tick
     """
-    print("\n================== Iteration 1-2 ==================\n")
-    for i in range(1, 3):
+    print("\n================== Iterations {}-{} ==================\n".format(from_tick, to_tick))
+    for i in range(from_tick, to_tick + 1):
         count = 0
         print(("\n--------- Run %s ---------\n" % i))
         for unused_node in root.tick():
             count += 1
+        if oneshot:
+            oneshot.logger.debug("OneShot.status[{}[{}]]".format(oneshot.status, oneshot.original.status))
     return count
+
+
+class Foo(py_trees.behaviour.Behaviour):
+
+    def __init__(self, name, what_am_i):
+        """
+        Constructor with the usual behaviour name argument plus
+        a custom argument.
+
+        Args:
+            name (:obj:`str`): the behaviour name
+            name (:obj:`str`): descriptive token for the behaviour
+        """
+        super(Foo, self).__init__(name)
+        self.what_am_i = what_am_i
 
 
 @py_trees.meta.oneshot
 class OneShotSequence(py_trees.composites.Sequence):
     pass
 
+
+class CounterTester(py_trees.behaviours.Count):
+
+    def __init__(self, *args, **kwargs):
+        super(CounterTester, self).__init__(*args, **kwargs)
+        self.terminate_count = 0
+        self.initialise_count = 0
+
+    def terminate(self, new_status):
+        super(CounterTester, self).terminate(new_status)
+        self.terminate_count += 1
+
+    def initialise(self):
+        super(CounterTester, self).initialise()
+        self.initialise_count += 1
+
 ##############################################################################
 # Tests
 ##############################################################################
+
+
+def test_custom_construction():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Construction Arguments are passed" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    oneshot = py_trees.meta.oneshot(Foo)(name="Oneshot",
+                                         what_am_i="Bar")
+    print(console.cyan + "What Am I: " + console.yellow + oneshot.what_am_i + console.reset)
+    assert(oneshot.what_am_i, "Bar")
 
 
 def test_oneshot_does_not_modify_class():
@@ -56,20 +107,150 @@ def test_oneshot_does_not_modify_class():
     print(console.bold + "****************************************************************************************\n" + console.reset)
     oneshot = py_trees.meta.oneshot(py_trees.composites.Sequence)(name="Oneshot",
                                                                   children=[py_trees.behaviours.Failure(name="Failure")])
-    oneshot_count = tick_tree(oneshot)
-    print(console.yellow + "\nOneshot Sequence Tick Count: {}".format(oneshot_count) + console.reset)
-
-    decorated_oneshot = OneShotSequence(name="Oneshot",
-                                        children=[py_trees.behaviours.Failure(name="Failure")])
-    decorated_oneshot_count = tick_tree(decorated_oneshot)
-    print(console.yellow + "\nDecorated Oneshot Sequence Tick Count: {}".format(decorated_oneshot_count) + console.reset)
-
-    normal = py_trees.composites.Sequence(name="Normal",
-                                          children=[py_trees.behaviours.Failure(name="Failure")])
-    normal_count = tick_tree(normal)
-    print(console.yellow + "\nNormal Sequence Tick Count: {}".format(normal_count) + console.reset)
+    oneshot_count = tick_tree(root=oneshot,
+                              oneshot=oneshot,
+                              from_tick=1,
+                              to_tick=2)
+    print(console.cyan + "\nOneshot Sequence Tick Count: " + console.yellow + "{}".format(oneshot_count) + console.reset)
     assert(oneshot_count == 1)
+
+    decorated_oneshot = OneShotSequence(
+        name="Oneshot",
+        children=[py_trees.behaviours.Failure(name="Failure")])
+    decorated_oneshot_count = tick_tree(root=decorated_oneshot,
+                                        oneshot=decorated_oneshot,
+                                        from_tick=1,
+                                        to_tick=2)
+    print(console.cyan + "\nDecorated Oneshot Sequence Tick Count: " + console.yellow + "{}".format(decorated_oneshot_count) + console.reset)
+    assert(decorated_oneshot_count == 1)
+
+    normal = py_trees.composites.Sequence(
+        name="Normal",
+        children=[py_trees.behaviours.Failure(name="Failure")])
+    normal_count = tick_tree(root=normal, oneshot=None, from_tick=1, to_tick=2)
+    print(console.cyan + "\nNormal Sequence Tick Count: " + console.yellow + "{}".format(normal_count) + console.reset)
     # Hitherto, the decorator modified the sequence permanently, so the tick count for the latter
     # would be the same. This behaviour is confusing - the decorators should always create
     # *new* classes so there is only one policy for decoration - instance modification only.
     assert(normal_count == 2)
+
+
+def test_priority_interrupt():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Priority Interrupt" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    oneshot = py_trees.meta.oneshot(py_trees.composites.Sequence)(name="Oneshot",
+                                                                  children=[py_trees.behaviours.Failure(name="Failure")])
+    # Tree with higher priority branch, Higher
+    root = py_trees.composites.Selector(name="Root")
+    fail_after_one = py_trees.behaviours.Count(name="HighPriority", fail_until=1, running_until=1, success_until=2)
+    root.add_children([fail_after_one, oneshot])
+    tick_tree(root=root, oneshot=oneshot, from_tick=1, to_tick=2)
+    print(console.cyan + "\nOneShot Status (After Interrupt): " + console.yellow + "{}".format(oneshot.status) + console.reset)
+    assert(oneshot.status == py_trees.common.Status.INVALID)
+    final_count = tick_tree(root=root, oneshot=oneshot, from_tick=3, to_tick=3)
+    print(console.cyan + "\nTick Count (After Resumption): " + console.yellow + "{}".format(final_count) + console.reset)
+    assert(final_count == 3)
+
+
+def test_running_sequence():
+    """
+    Makes sure proper responses are returned from a oneshot sequence
+    with running children.
+    """
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Running Sequence" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    run_a_bit = py_trees.behaviours.Count(name="RunABit", fail_until=0, running_until=2, success_until=5)
+    oneshot = py_trees.meta.oneshot(py_trees.composites.Sequence)(
+        name="Oneshot",
+        children=[run_a_bit])
+    count = tick_tree(root=oneshot, oneshot=oneshot, from_tick=1, to_tick=4)
+    assert(count == 1)
+
+
+def test_oneshot_does_not_re_initialise():
+    """
+    Makes sure that a oneshot behaviour does not re-initialise once it
+    has run through to completion (SUCCESS || FAILURE). It also checks
+    to make sure it blocks on needless termination calls coming from
+    priority interrupts / resets.
+    """
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* OneShot does not ReIinitialise" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    success = py_trees.behaviours.Success(name="Success")
+    tester = py_trees.meta.oneshot(CounterTester)(
+        name="Tester",
+        fail_until=0,
+        running_until=0,
+        success_until=1000,
+        reset=False)
+    root = py_trees.composites.Sequence(
+        name="Sequence", children=[success, tester])
+    tick_tree(root, tester, 1, 5)
+    assert(tester.status == py_trees.common.Status.SUCCESS)
+    print("\n")
+    print(console.cyan + "Terminate Count: " + console.yellow + "{}".format(tester.terminate_count) + console.reset)
+    print(console.cyan + "Initialize Count: " + console.yellow + "{}".format(tester.initialise_count) + console.reset)
+    assert(tester.initialise_count == 1)
+
+
+def test_oneshot_does_re_initialise():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* OneShot does ReIinitialise" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    """Makes sure that the oneshot decorator calls terminate and
+    initialise if they were called due to early termination involving
+    an INVALID new_status. Also ensures that it does not call it
+    after it reports SUCCESS.
+    """
+    NUM_TICKS = 10
+    periodic_success = py_trees.behaviours.SuccessEveryN(
+        name="Periodic_Fail", n=2)
+    tester = py_trees.meta.oneshot(CounterTester)(
+        name="Tester",
+        fail_until=0,
+        running_until=2,
+        success_until=1000,
+        reset=False)
+    root = py_trees.composites.Selector(
+        name="Selector", children=[
+            periodic_success, tester])
+    # Alternating Failure and Success.
+    periodic_expected_status = [
+        py_trees.common.Status.SUCCESS
+        if (n % 2 == 1) else py_trees.common.Status.FAILURE for n in range(NUM_TICKS)]
+    tester_expected_status = [py_trees.common.Status.RUNNING,  # First initialise()
+                              py_trees.common.Status.INVALID,  # First terminate()
+                              py_trees.common.Status.RUNNING,  # Second initialise()
+                              py_trees.common.Status.INVALID,  # Second terminate()
+                              py_trees.common.Status.SUCCESS,  # Third initialise() and terminate()
+                              py_trees.common.Status.INVALID,
+                              py_trees.common.Status.SUCCESS,
+                              py_trees.common.Status.INVALID,
+                              py_trees.common.Status.SUCCESS,
+                              py_trees.common.Status.INVALID
+                              ]
+    root_expected_status = [py_trees.common.Status.RUNNING,
+                            py_trees.common.Status.SUCCESS,
+                            py_trees.common.Status.RUNNING,
+                            py_trees.common.Status.SUCCESS,
+                            py_trees.common.Status.SUCCESS,
+                            py_trees.common.Status.SUCCESS,
+                            py_trees.common.Status.SUCCESS,
+                            py_trees.common.Status.SUCCESS,
+                            py_trees.common.Status.SUCCESS,
+                            py_trees.common.Status.SUCCESS,
+                            ]
+    for i in range(NUM_TICKS):
+        root.tick_once()
+        py_trees.display.print_ascii_tree(root, 0, show_status=True)
+        assert(root.status == root_expected_status[i])
+        assert(tester.status == tester_expected_status[i])
+        assert(periodic_success.status == periodic_expected_status[i])
+    print("\n")
+    print(console.cyan + "Terminate Count: " + console.yellow + "{}".format(tester.terminate_count) + console.reset)
+    print(console.cyan + "Initialize Count: " + console.yellow + "{}".format(tester.initialise_count) + console.reset)
+    assert(tester.terminate_count == 3)
+    assert(tester.initialise_count == 3)


### PR DESCRIPTION
Issue details in #90.

* [x] reproducable test
* [x] switch to imposter usage
* [x] proof against priority interrupts
* [x] make sure `new_status=INVALID` from interrupts/resets actually becomes `status=INVALID`