### PR TITLE
Parallels should invalidate running children on completion

### DIFF
--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -589,7 +589,8 @@ class Parallel(Composite):
         if new_status != Status.RUNNING:
             for child in self.children:
                 if child.status == Status.RUNNING:
-                    child.stop(new_status)
+                    # interrupt it (exactly as if it was interrupted by a higher priority)
+                    child.stop(Status.INVALID)
             self.stop(new_status)
         self.status = new_status
         yield self

--- a/tests/test_parallels.py
+++ b/tests/test_parallels.py
@@ -76,7 +76,12 @@ def test_parallel_running():
     print(console.bold + "* Parallel Running" + console.reset)
     print(console.bold + "****************************************************************************************\n" + console.reset)
     root = py_trees.composites.Parallel("Parallel", policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL)
-    success_after_1 = py_trees.behaviours.Count(name="SuccessAfter1", fail_until=0, running_until=1, success_until=20)
+    success_after_1 = py_trees.behaviours.Count(
+        name="SuccessAfter1",
+        fail_until=0,
+        running_until=1,
+        success_until=20,
+        reset=False)
 
     running = py_trees.behaviours.Running("Running")
     success_every_other = py_trees.behaviours.SuccessEveryN("SuccessEveryOther", 2)
@@ -90,10 +95,10 @@ def test_parallel_running():
     print("\n--------- Assertions ---------\n")
     print("root.status == py_trees.Status.FAILURE")
     assert(root.status == py_trees.Status.FAILURE)
-    print("success_after_1.status == py_trees.Status.FAILURE")
-    assert(success_after_1.status == py_trees.Status.FAILURE)
-    print("running.status == py_trees.Status.FAILURE")
-    assert(running.status == py_trees.Status.FAILURE)
+    print("success_after_1.status == py_trees.Status.INVALID")
+    assert(success_after_1.status == py_trees.Status.INVALID)
+    print("running.status == py_trees.Status.INVALID")
+    assert(running.status == py_trees.Status.INVALID)
     print("success_every_other.status == py_trees.Status.FAILURE")
     assert(success_every_other.status == py_trees.Status.FAILURE)
 
@@ -130,10 +135,10 @@ def test_parallel_success_on_one():
     print("All children get switched to success if one goes to success.")
     print("root.status == py_trees.Status.SUCCESS")
     assert(root.status == py_trees.Status.SUCCESS)
-    print("running1.status == py_trees.Status.SUCCESS")
-    assert(running1.status == py_trees.Status.SUCCESS)
+    print("running1.status == py_trees.Status.INVALID")
+    assert(running1.status == py_trees.Status.INVALID)
     print("success.status == py_trees.Status.SUCCESS")
     assert(success.status == py_trees.Status.SUCCESS)
-    print("running2.status == py_trees.Status.SUCCESS")
-    assert(running2.status == py_trees.Status.SUCCESS)
+    print("running2.status == py_trees.Status.INVALID")
+    assert(running2.status == py_trees.Status.INVALID)
 


### PR DESCRIPTION
Previously they were passing on the parent's status. Children should be completely unaware of what their parent is doing (compare with the Selector).

Aims to resolve #93.

Note: the parallel's test logic was awry :/