### PR TITLE
Sequence without memory

### DIFF
--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -528,6 +528,80 @@ class Sequence(Composite):
 
 
 ##############################################################################
+# Series (Not sure what a good name would be)
+##############################################################################
+
+
+class Series(Sequence):
+    """
+    Series are the factory lines of Behaviour Trees
+
+    .. graphviz:: dot/sequence.dot
+
+    A Series will progressively tick over each of its children so long as
+    each child returns :data:`~py_trees.common.Status.SUCCESS`. If any child returns
+    :data:`~py_trees.common.Status.FAILURE` or :data:`~py_trees.common.Status.RUNNING` the sequence will halt,
+    all future children will be haulted and the parent will adopt
+    the result of this child. If it reaches the last child, it returns with
+    that result regardless.
+
+    .. note::
+
+       The Series halts once it sees a child is RUNNING and then returns
+       the result. *It does not get stuck in the running behaviour*.
+
+    .. seealso:: The :ref:`py-trees-demo-sequence-program` program demos a simple sequence in action.
+
+    Args:
+        name (:obj:`str`): the composite behaviour name
+        children ([:class:`~py_trees.behaviour.Behaviour`]): list of children to add
+        *args: variable length argument list
+        **kwargs: arbitrary keyword arguments
+
+    """
+    def __init__(self, name="Series", children=None, *args, **kwargs):
+        super(Series, self).__init__(name, children, *args, **kwargs)
+        self.current_index = -1  # -1 indicates uninitialised
+
+    def tick(self):
+        """
+        Tick over the children.
+
+        Yields:
+            :class:`~py_trees.behaviour.Behaviour`: a reference to itself or one of its children
+        """
+        self.logger.debug("%s.tick()" % self.__class__.__name__)
+        self.current_index = 0
+        if self.status != Status.RUNNING:
+            self.logger.debug("%s.tick() [resetting]" % self.__class__.__name__)
+            # sequence specific handling
+            for child in self.children:
+                # reset the children, this helps when introspecting the tree
+                if child.status != Status.INVALID:
+                    child.stop(Status.INVALID)
+            # subclass (user) handling
+            self.initialise()
+        # run any work designated by a customised instance of this class
+        self.update()
+        for child in self.children:
+            for node in child.tick():
+                yield node
+                if node is child and node.status != Status.SUCCESS:
+                    self.status = node.status
+                    # If status is running all future nodes must be stoped in case they are already running
+                    for child in itertools.islice(self.children, self.current_index + 1, None):
+                        if child.status != Status.INVALID:
+                            child.stop(Status.INVALID)
+                    yield self
+                    return
+            self.current_index += 1
+        # At this point, all children are happy with their SUCCESS, so we should be happy too
+        self.current_index -= 1  # went off the end of the list if we got to here
+        self.stop(Status.SUCCESS)
+        yield self
+
+
+##############################################################################
 # Parallel
 ##############################################################################
 

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+#
+# License: BSD
+#   https://raw.githubusercontent.com/stonier/py_trees/devel/LICENSE
+#
+
+##############################################################################
+# Imports
+##############################################################################
+
+# enable some python3 compatibility options:
+# (unicode_literals not compatible with python2 uuid module)
+from __future__ import absolute_import, print_function
+
+import py_trees
+import py_trees.console as console
+
+##############################################################################
+# Logging Level
+##############################################################################
+
+py_trees.logging.level = py_trees.logging.Level.DEBUG
+logger = py_trees.logging.Logger("Nosetest")
+
+##############################################################################
+# Tests
+##############################################################################
+
+def test_series_suceess():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Series Success" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    root = py_trees.composites.Series('Series')
+    success = py_trees.behaviours.Success("Success")
+
+    root.add_child(success)
+    py_trees.display.print_ascii_tree(root)
+    visitor = py_trees.visitors.DebugVisitor()
+
+    py_trees.tests.tick_tree(root, visitor, 1, 1)
+
+    print("\n--------- Assertions ---------\n")
+    print("root.status == py_trees.Status.SUCCESS")
+    assert(root.status == py_trees.Status.SUCCESS)
+    print("success.status == py_trees.Status.SUCCESS")
+    assert(success.status == py_trees.Status.SUCCESS)
+
+
+def test_series_failure():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Series Failure" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    root = py_trees.composites.Series('Series')
+    failure = py_trees.behaviours.Failure("Failure")
+
+    root.add_child(failure)
+    py_trees.display.print_ascii_tree(root)
+    visitor = py_trees.visitors.DebugVisitor()
+
+    py_trees.tests.tick_tree(root, visitor, 1, 1)
+
+    print("\n--------- Assertions ---------\n")
+    print("root.status == py_trees.Status.FAILURE")
+    assert(root.status == py_trees.Status.FAILURE)
+    print("failure.status == py_trees.Status.FAILURE")
+    assert(failure.status == py_trees.Status.FAILURE)
+
+
+def test_series_running():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Series Running" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    root = py_trees.composites.Series('Series')
+    success = py_trees.behaviours.Success("Success")
+    running = py_trees.behaviours.Running("Running")
+
+    root.add_child(success)
+    root.add_child(running)
+    py_trees.display.print_ascii_tree(root)
+    visitor = py_trees.visitors.DebugVisitor()
+
+    py_trees.tests.tick_tree(root, visitor, 1, 1)
+
+    print("\n--------- Assertions ---------\n")
+    print("root.status == py_trees.Status.RUNNING")
+    assert(root.status == py_trees.Status.RUNNING)
+    print("success.status == py_trees.Status.SUCCESS")
+    assert(success.status == py_trees.Status.SUCCESS)
+    print("running.status == py_trees.Status.RUNNING")
+    assert(running.status == py_trees.Status.RUNNING)
+
+
+def test_series_stop_future_children():
+    print(console.bold + "\n****************************************************************************************" + console.reset)
+    print(console.bold + "* Series Stop Future Children" + console.reset)
+    print(console.bold + "****************************************************************************************\n" + console.reset)
+    root = py_trees.composites.Series('Series')
+    periodic = py_trees.behaviours.Periodic(name="periodic", n=0)
+    running = py_trees.behaviours.Running("Running")
+
+    root.add_child(periodic)
+    root.add_child(running)
+    py_trees.display.print_ascii_tree(root)
+    visitor = py_trees.visitors.DebugVisitor()
+
+    py_trees.tests.tick_tree(root, visitor, 1, 1)
+
+    print("\n--------- Assertions ---------\n")
+    print("root.status == py_trees.Status.RUNNING")
+    assert(root.status == py_trees.Status.RUNNING)
+    print("periodic.status == py_trees.Status.SUCCESS")
+    assert(periodic.status == py_trees.Status.SUCCESS)
+    print("running.status == py_trees.Status.RUNNING")
+    assert(running.status == py_trees.Status.RUNNING)
+
+    py_trees.tests.tick_tree(root, visitor, 2, 2)
+
+    print("\n--------- Assertions ---------\n")
+    print("root.status == py_trees.Status.FAILURE")
+    assert(root.status == py_trees.Status.FAILURE)
+    print("periodic.status == py_trees.Status.FAILURE")
+    assert(periodic.status == py_trees.Status.FAILURE)
+    print("running.status == py_trees.Status.INVALID")
+    assert(running.status == py_trees.Status.INVALID)
+
+    py_trees.tests.tick_tree(root, visitor, 3, 3)
+
+    print("\n--------- Assertions ---------\n")
+    print("root.status == py_trees.Status.RUNNING")
+    assert(root.status == py_trees.Status.RUNNING)
+    print("periodic.status == py_trees.Status.RUNNING")
+    assert(periodic.status == py_trees.Status.RUNNING)
+    print("running.status == py_trees.Status.INVALID")
+    assert(running.status == py_trees.Status.INVALID)
+


### PR DESCRIPTION
Before switching to py_trees my lab was using https://github.com/miccol/ROS-Behavior-Tree. This software had the concept of a sequence and fallback(selector) with memory or without. py_trees has memory and memoryless fallbacks the chooser and the selector respectively. This is not the case for sequences. py_trees sequences are basically ROS-Behavior-Tree sequence with memory.

Is there a reason for leaving out a sequence without memory? I used it a lot in ROS-Behavior-Tree and found it quite useful. It is especially useful in the case of a guard condition that must remain true for the entire execution of an action.

I've added what I think would be a good implementation of a sequence without memory. I'm up for suggestions on names although series has been growing on me.