### PR TITLE
Properly set parent field for replacement in Behaviour.replace_child()

### DIFF
--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -193,6 +193,7 @@ class Composite(Behaviour):
         child_index = self.children.index(child)
         self.logger.debug("%s.replace_child()[%s->%s]" % (self.__class__.__name__, child.name, replacement.name))
         self.children[child_index] = replacement
+        replacement.parent = self
 
     def remove_child_by_id(self, child_id):
         """


### PR DESCRIPTION
Not setting the parent causes problems if you try to replace a child that was previously replaced.

For example (pseudocode):
```python
root = py_trees.composites.Sequence()
child0 = # ... (a Behaviour with id "0")
root.add_child(child0)
tree = py_trees.trees.BehaviourTree(root)

child1 = # ... (a Behaviour with id "1")
tree.replace_tree("0", child1)  # succeeds

child2 = # ... (a Behaviour with id "2")
tree.replace_tree("1", child2)  # fails! This returns None because the child1's parent was None.
```