### PR TITLE
Add unset helper method to blackboard

### DIFF
--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -132,6 +132,19 @@ class Blackboard(object):
         except AttributeError:
             return None
 
+    def unset(self, name):
+        """
+        For when you need to unset a blackboard variable, this provides a convenient helper method.
+        This is particularly useful for unit testing behaviours.
+
+        Args:
+            name (:obj:`str`): name of the variable to unset
+        """
+        try:
+            delattr(self, name)
+        except AttributeError:
+            pass
+
     def __str__(self):
         """
         Express the blackboard contents as a string. Useful for debugging.
@@ -181,10 +194,7 @@ class ClearBlackboardVariable(behaviours.Success):
         Delete the variable from the blackboard.
         """
         self.blackboard = Blackboard()
-        try:
-            delattr(self.blackboard, self.variable_name)
-        except AttributeError:
-            pass
+        self.blackboard.unset(self.variable_name)
 
 
 class SetBlackboardVariable(behaviours.Success):


### PR DESCRIPTION
This is a very helpful helper method for unit testing behaviours. Often, our behaviours have logic to check if a required blackboard variable is set or not. Because the blackboard is a singleton, we need to explicitly unset a variable on test tearDown, as opposed to just setting it to None. This ensures that previous tests haven't set the variable already.