### PR TITLE
[blackboard] method for clearing the blackboard

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Release Notes
 **New Features**
 
 * [composites] raise TypeError when setup methods don't return a bool (common mistake)
+* [blackboard] method for clearing the blackboard
 
 0.8.x (2018-10-18)
 ------------------

--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -92,7 +92,16 @@ class Blackboard(object):
 
     .. seealso:: The :ref:`py-trees-demo-blackboard-program` program demos use of the blackboard along with a couple of the blackboard behaviours.
     """
+    # Dunder style to avoid collisions
     __shared_state = {}
+
+    @staticmethod
+    def clear():
+        """
+        Erase the blackboard contents. Typically this is used only when you
+        have repeated runs of different tree instances, as often happens in testing.
+        """
+        Blackboard.__shared_state.clear()
 
     def __init__(self):
         self.__dict__ = self.__shared_state


### PR DESCRIPTION
Necessary for testing when you run repeated instances of trees
and you want to make sure you can start with a clean blackboard
each time.