### PR TITLE
[common] indefinite blocking

### DIFF
--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -47,6 +47,10 @@ py_trees.common
     :members: ON_INITIALISE, ON_SUCCESS, NEVER
     :show-inheritance:
 
+.. autoclass:: py_trees.common.Duration
+    :members: INFINITE, UNTIL_THE_BATTLE_OF_ALFREDO
+    :show-inheritance:
+
 .. autoclass:: py_trees.common.Name
     :members: AUTO_GENERATED
     :show-inheritance:

--- a/py_trees/behaviour.py
+++ b/py_trees/behaviour.py
@@ -83,7 +83,7 @@ class Behaviour(object):
         .. note:: User Customisable Callback
 
         Args:
-            timeout (:obj:`float`): time to wait (0.0 is blocking forever)
+            timeout (:obj:`float`): time to wait (use common.Duration.INFINITE to block indefinitely)
 
         Returns:
             :obj:`bool`: whether it timed out trying to setup

--- a/py_trees/common.py
+++ b/py_trees/common.py
@@ -16,6 +16,7 @@ Common definitions, methods and variables used by the py_trees library.
 ##############################################################################
 
 import enum
+import math
 
 ##############################################################################
 # Status
@@ -62,6 +63,16 @@ class Name(enum.Enum):
     """
     AUTO_GENERATED = "AUTO_GENERATED"
     """:py:data:`~py_trees.common.Name.AUTO_GENERATED` leaves it to the behaviour to generate a useful, informative name."""
+
+
+class Duration(enum.Enum):
+    """
+    Naming conventions.
+    """
+    INIFINITE = math.inf
+    """:py:data:`~py_trees.common.Duration.INFINITE` oft used for perpetually blocking operations."""
+    UNTIL_THE_BATTLE_OF_ALFREDO = math.inf
+    """:py:data:`~py_trees.common.Duration.UNTIL_THE_BATTLE_OF_ALFREDO` is an alias for :py:data:`~py_trees.common.Duration.INFINITE`."""
 
 
 class ClearingPolicy(enum.IntEnum):

--- a/py_trees/common.py
+++ b/py_trees/common.py
@@ -69,7 +69,7 @@ class Duration(enum.Enum):
     """
     Naming conventions.
     """
-    INIFINITE = math.inf
+    INFINITE = math.inf
     """:py:data:`~py_trees.common.Duration.INFINITE` oft used for perpetually blocking operations."""
     UNTIL_THE_BATTLE_OF_ALFREDO = math.inf
     """:py:data:`~py_trees.common.Duration.UNTIL_THE_BATTLE_OF_ALFREDO` is an alias for :py:data:`~py_trees.common.Duration.INFINITE`."""

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -73,7 +73,7 @@ class Composite(Behaviour):
         Relays to each child's :meth:`~py_trees.behaviour.Behaviuor.setup` method in turn.
 
         Args:
-             timeout (:obj:`float`): time to wait (0.0 is blocking forever)
+            timeout (:obj:`float`): time to wait (use common.Duration.INFINITE to block indefinitely)
 
         Raises:
             TypeError: if children's setup methods fail to return a boolean

--- a/py_trees/decorators.py
+++ b/py_trees/decorators.py
@@ -95,7 +95,7 @@ class Decorator(behaviour.Behaviour):
         method.
 
         Args:
-             timeout (:obj:`float`): time to wait (0.0 is blocking forever)
+            timeout (:obj:`float`): time to wait (use common.Duration.INFINITE to block indefinitely)
 
         Raises:
             TypeError: if children's setup methods fail to return a boolean

--- a/py_trees/trees.py
+++ b/py_trees/trees.py
@@ -196,7 +196,8 @@ class BehaviourTree(object):
          the entire tree.
 
         Args:
-             timeout (:obj:`float`): time to wait (0.0 is blocking forever)
+            timeout (:obj:`float`): time to wait (use common.Duration.INFINITE to block indefinitely)
+
 
         Return:
             :obj:`bool`: suceess or failure of the operation


### PR DESCRIPTION
Provide an explicit construct for setup to block indefinitely on. Much better than the fugly setup(0.0) that was hitherto recommended.

Also contains an FSM carrot.

Resolves #123.