### PR TITLE
[display] render parallel policies and fully qualified names in dot

### DIFF
--- a/doc/dot/parallel.dot
+++ b/doc/dot/parallel.dot
@@ -1,10 +1,12 @@
 digraph pastafarianism {
-graph [fontname="times-roman"];
+graph [fontname="times-roman", splines=curved];
 node [fontname="times-roman"];
 edge [fontname="times-roman"];
-Parallel [fillcolor=gold, fontcolor=black, fontsize=11, shape=parallelogram, style=filled];
-B1 [fillcolor=gray, fontcolor=black, fontsize=11, shape=ellipse, style=filled];
+Parallel [fillcolor=gold, fontcolor=black, fontsize=9, label="Parallel\n--SuccessOnSelected(⚡,[B1,B2])--", shape=parallelogram, style=filled];
+B1 [fillcolor=gray, fontcolor=black, fontsize=9, label=B1, shape=ellipse, style=filled];
 Parallel -> B1;
-B2 [fillcolor=gray, fontcolor=black, fontsize=11, shape=ellipse, style=filled];
+B2 [fillcolor=gray, fontcolor=black, fontsize=9, label=B2, shape=ellipse, style=filled];
 Parallel -> B2;
+B3 [fillcolor=gray, fontcolor=black, fontsize=9, label=B3, shape=ellipse, style=filled];
+Parallel -> B3;
 }

--- a/doc/examples/parallel.py
+++ b/doc/examples/parallel.py
@@ -3,8 +3,14 @@
 import py_trees
 
 if __name__ == '__main__':
-    root = py_trees.composites.Parallel("Parallel")
     b1 = py_trees.behaviours.Success(name="B1")
     b2 = py_trees.behaviours.Success(name="B2")
-    root.add_children([b1, b2])
+    b3 = py_trees.behaviours.Success(name="B3")
+    root = py_trees.composites.Parallel(
+        policy=py_trees.common.ParallelPolicy.SuccessOnSelected(
+            synchronise=True,
+            children=[b1, b2]
+        )
+    )
+    root.add_children([b1, b2, b3])
     py_trees.display.render_dot_tree(root, py_trees.common.string_to_visibility_level("all"))

--- a/doc/examples/pickup_where_you_left_off.py
+++ b/doc/examples/pickup_where_you_left_off.py
@@ -16,9 +16,10 @@ if __name__ == '__main__':
         success_until=10
     )
     high_priority_interrupt = py_trees.decorators.RunningIsFailure(
-        py_trees.behaviours.Periodic)(
-        name="High Priority",
-        n=3
+        child=py_trees.behaviours.Periodic(
+            name="High Priority",
+            n=3
+        )
     )
     piwylo = py_trees.idioms.pick_up_where_you_left_off(
         name="Tasks",
@@ -26,4 +27,6 @@ if __name__ == '__main__':
     )
     root = py_trees.composites.Selector(name="Pick Up\nWhere You\nLeft Off")
     root.add_children([high_priority_interrupt, piwylo])
-    py_trees.display.render_dot_tree(root, py_trees.common.string_to_visibility_level("all"))
+    py_trees.display.render_dot_tree(
+        root,
+        py_trees.common.string_to_visibility_level("all"))

--- a/py_trees/behaviour.py
+++ b/py_trees/behaviour.py
@@ -60,7 +60,7 @@ class Behaviour(object):
        * :ref:`The Action Behaviour Demo <py-trees-demo-action-behaviour-program>`
 
     """
-    def __init__(self, name, *args, **kwargs):
+    def __init__(self, name=common.Name.AUTO_GENERATED, *args, **kwargs):
         if not name or name == common.Name.AUTO_GENERATED:
             name = self.__class__.__name__
         if not isinstance(name, str):

--- a/py_trees/behaviour.py
+++ b/py_trees/behaviour.py
@@ -60,7 +60,9 @@ class Behaviour(object):
        * :ref:`The Action Behaviour Demo <py-trees-demo-action-behaviour-program>`
 
     """
-    def __init__(self, name="", *args, **kwargs):
+    def __init__(self, name, *args, **kwargs):
+        if not name or name == common.Name.AUTO_GENERATED:
+            name = self.__class__.__name__
         if not isinstance(name, str):
             raise TypeError("a behaviour name should be a string, but you passed in {}".format(type(name)))
         self.id = uuid.uuid4()  # used to uniquely identify this node (helps with removing children from a tree)
@@ -84,20 +86,20 @@ class Behaviour(object):
         done here rather than in __init__ so that trees can be instantiated on the fly for
         easy rendering to dot graphs without imposing runtime requirements (e.g. establishing
         a middleware connection to a sensor).
-        
+
         Equally as important, executing methods here which validate the configuration of
         behaviours will help increase confidence that your tree will successfully tick
         without logical software errors before actually ticking. This is useful both
         before a tree's first tick and immediately after any modifications to a tree
         has been made between ticks.
-        
+
         .. tip::
 
            * If there are children, be sure to recursively call this function on each one so
              that a single setup invocation at the root of a tree will traverse the entire tree.
            * Faults are notified to the user of the behaviour via exceptions. Choice of exception to
              use is left to the user.
-        
+
         .. note:: User Customisable Callback
 
         Args:
@@ -312,3 +314,16 @@ class Behaviour(object):
         self.terminate(new_status)
         self.status = new_status
         self.iterator = self.tick()
+
+    def verbose_info_string(self):
+        """
+        Override to provide a one line informative string about the behaviour. This
+        gets used in, e.g. dot graph rendering of the tree.
+
+        .. tip::
+           Use this sparingly. A good use case is for when the behaviour type
+           and class name isn't sufficient to inform the user about it's
+           mechanisms for controlling the flow of a tree tick (e.g. parallels
+           with policies).
+        """
+        return ""

--- a/py_trees/behaviours.py
+++ b/py_trees/behaviours.py
@@ -42,6 +42,12 @@ def running(self):
     return Status.RUNNING
 
 
+def dummy(self):
+    self.logger.debug("%s.update()" % self.__class__.__name__)
+    self.feedback_message = "crash test dummy"
+    return Status.RUNNING
+
+
 Success = meta.create_behaviour_from_function(success)
 """
 Do nothing but tick over with :data:`~py_trees.common.Status.SUCCESS`.
@@ -55,6 +61,11 @@ Do nothing but tick over with :data:`~py_trees.common.Status.FAILURE`.
 Running = meta.create_behaviour_from_function(running)
 """
 Do nothing but tick over with :data:`~py_trees.common.Status.RUNNING`.
+"""
+
+Dummy = meta.create_behaviour_from_function(dummy)
+"""
+Crash test dummy used for anything dangerous.
 """
 
 ##############################################################################

--- a/py_trees/common.py
+++ b/py_trees/common.py
@@ -67,6 +67,15 @@ class ParallelPolicy(object):
             """
             super().__init__(synchronise=synchronise)
 
+        def __str__(self) -> str:
+            """
+            Human readable description.
+            """
+            description = "--" + self.__class__.__name__ + "("
+            description += u'\u26A1' if self.synchronise else "-"  # lightning bolt
+            description += "--"
+            return description
+
     class SuccessOnOne(Base):
         """
         Return :py:data:`~py_trees.common.Status.SUCCESS` so long as at least one child has :py:data:`~py_trees.common.Status.SUCCESS`
@@ -77,6 +86,12 @@ class ParallelPolicy(object):
             No configuration necessary for this policy.
             """
             super().__init__(synchronise=False)
+
+        def __str__(self) -> str:
+            """
+            Human readable description.
+            """
+            return "--" + self.__class__.__name__ + "--"
 
     class SuccessOnSelected(Base):
         """
@@ -93,6 +108,17 @@ class ParallelPolicy(object):
             """
             super().__init__(synchronise=synchronise)
             self.children = children
+
+        def __str__(self) -> str:
+            """
+            Human readable description.
+            """
+            description = "--" + self.__class__.__name__ + "("
+            description += u'\u26A1' if self.synchronise else "-"  # lightning bolt
+            description += ","
+            description += "[" + ",".join([c.name for c in self.children]) + "]"
+            description += ")--"
+            return description
 
 
 class OneShotPolicy(enum.Enum):
@@ -125,7 +151,6 @@ class Duration(enum.Enum):
 class ClearingPolicy(enum.IntEnum):
     """
     Policy rules for behaviours to dictate when data should be cleared/reset.
-    Used by the :py:mod:`~py_trees.subscribers` module.
     """
     ON_INITIALISE = 1
     """Clear when entering the :py:meth:`~py_trees.behaviour.Behaviour.initialise` method."""

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -58,7 +58,7 @@ class Composite(behaviour.Behaviour):
         *args: variable length argument list
         **kwargs: arbitrary keyword arguments
     """
-    def __init__(self, name="", children=None, *args, **kwargs):
+    def __init__(self, name, children=None, *args, **kwargs):
         super(Composite, self).__init__(name, *args, **kwargs)
         if children is not None:
             for child in children:
@@ -567,7 +567,7 @@ class Parallel(Composite):
        * :ref:`Context Switching Demo <py-trees-demo-context-switching-program>`
     """
     def __init__(self,
-                 name: str="Parallel",
+                 name: str=common.Name.AUTO_GENERATED,
                  policy: common.ParallelPolicy.Base=common.ParallelPolicy.SuccessOnAll(),
                  children: typing.List[behaviour.Behaviour]=None
                  ):
@@ -591,6 +591,7 @@ class Parallel(Composite):
             RuntimeError: if the parallel's policy configuration is invalid
             Exception: be ready to catch if any of the children raise an exception
         """
+        del timeout  # unused parameter
         self.validate_policy_configuration()
 
     def tick(self):
@@ -670,6 +671,15 @@ class Parallel(Composite):
             return success_children[-1]
         else:  # RUNNING
             return self.children[-1]
+
+    def verbose_info_string(self) -> str:
+        """
+        Provide additional information about the underlying policy.
+
+        Returns:
+            :obj:`str`: name of the policy along with it's configuration
+        """
+        return str(self.policy)
 
     def validate_policy_configuration(self):
         """

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -58,7 +58,12 @@ class Composite(behaviour.Behaviour):
         *args: variable length argument list
         **kwargs: arbitrary keyword arguments
     """
-    def __init__(self, name, children=None, *args, **kwargs):
+    def __init__(self,
+                 name: str=common.Name.AUTO_GENERATED,
+                 children=None,
+                 *args,
+                 **kwargs
+                 ):
         super(Composite, self).__init__(name, *args, **kwargs)
         if children is not None:
             for child in children:
@@ -591,7 +596,6 @@ class Parallel(Composite):
             RuntimeError: if the parallel's policy configuration is invalid
             Exception: be ready to catch if any of the children raise an exception
         """
-        del timeout  # unused parameter
         self.validate_policy_configuration()
 
     def tick(self):

--- a/py_trees/decorators.py
+++ b/py_trees/decorators.py
@@ -94,7 +94,7 @@ class Decorator(behaviour.Behaviour):
         name construction (if None is given).
 
         Args:
-            name (:obj:`str`): the decorator name (can be None)
+            name (:obj:`str`): the decorator name
             child (:class:`~py_trees.behaviour.Behaviour`): the child to be decorated
 
         Raises:
@@ -103,9 +103,6 @@ class Decorator(behaviour.Behaviour):
         # Checks
         if not isinstance(child, behaviour.Behaviour):
             raise TypeError("A decorator's child must be an instance of py_trees.behaviours.Behaviour")
-        # Construct an informative name if none is provided
-        if not name or name == common.Name.AUTO_GENERATED:
-            name = self.__class__.__name__ + "\n[{}]".format(child.name)
         # Initialise
         super(Decorator, self).__init__(name=name)
         self.children.append(child)

--- a/py_trees/display.py
+++ b/py_trees/display.py
@@ -231,7 +231,7 @@ def generate_pydot_graph(root, visibility_level, collapse_decorators, with_quali
         root (:class:`~py_trees.behaviour.Behaviour`): the root of a tree, or subtree
         visibility_level (:class`~py_trees.common.VisibilityLevel`): collapse subtrees at or under this level
         collapse_decorators (:obj:`bool`): only show the decorator (not the child)
-        with_class_names: (:obj:`bool`): print the class information for each behaviour in each node
+        with_qualified_names: (:obj:`bool`): print the class information for each behaviour in each node
 
     Returns:
         pydot.Dot: graph

--- a/py_trees/display.py
+++ b/py_trees/display.py
@@ -298,6 +298,9 @@ def generate_pydot_graph(root, visibility_level, collapse_decorators, with_quali
                 while node_name in names:
                     node_name += "*"
                 names.append(c.name)
+                # Node attributes can be found on page 5 of
+                #    https://graphviz.gitlab.io/_pages/pdf/dot.1.pdf
+                # Attributes that may be useful: tooltip, xlabel
                 node = pydot.Node(
                     node_name,
                     label=get_node_label(node_name, c),
@@ -306,8 +309,6 @@ def generate_pydot_graph(root, visibility_level, collapse_decorators, with_quali
                     fillcolor=node_colour,
                     fontsize=fontsize,
                     fontcolor=node_font_colour,
-                    # tooltip="foo",
-                    # xlabel="dunders"  # shows up like a stray cat somewhere to the topleft of the node in dot, png's
                 )
                 graph.add_node(node)
                 edge = pydot.Edge(root_dot_name, node_name)

--- a/py_trees/display.py
+++ b/py_trees/display.py
@@ -32,8 +32,9 @@ from . import utilities
 # Methods
 ##############################################################################
 
+
 @utilities.static_variables(
-    type_to_unicode = {
+    type_to_unicode={
         composites.Sequence: "[-] ",
         composites.Selector: "[o] ",
         composites.Parallel: "[" + u'\u2016' + "] ",
@@ -44,10 +45,10 @@ from . import utilities
 def ascii_bullet(node):
     """
     Generate a text bullet for the specified behaviour's type.
-    
+
     Args:
         node (:class:`~py_trees.behaviour.Behaviour`): convert this behaviour's type to text
-        
+
     Returns:
         :obj:`str`): the text bullet
     """
@@ -59,8 +60,9 @@ def ascii_bullet(node):
             return ascii_bullet.type_to_unicode[behaviour_type]
     return ascii_bullet.type_to_unicode[behaviour.Behaviour]
 
+
 @utilities.static_variables(
-    status_to_unicode = {
+    status_to_unicode={
         common.Status.SUCCESS: console.green + u'\u2713' + console.reset,
         common.Status.FAILURE: console.red + u'\u2715' + console.reset,
         common.Status.INVALID: console.yellow + u'-' + console.reset,
@@ -70,14 +72,15 @@ def ascii_bullet(node):
 def ascii_check_mark(status):
     """
     Generate a text check mark for the specified status.
-    
+
     Args:
         status (:class:`~py_trees.common.Status`): convert this status to text
-        
+
     Returns:
         :obj:`str`): the text check mark
     """
     return ascii_check_mark.status_to_unicode[status]
+
 
 def _generate_ascii_tree(tree, indent=0, snapshot_information=None):
     """
@@ -219,7 +222,7 @@ def print_ascii_tree(root, indent=0, show_status=False):
         print("%s" % line)
 
 
-def generate_pydot_graph(root, visibility_level, collapse_decorators):
+def generate_pydot_graph(root, visibility_level, collapse_decorators, with_qualified_names):
     """
     Generate the pydot graph - this is usually the first step in
     rendering the tree to file. See also :py:func:`render_dot_tree`.
@@ -228,11 +231,12 @@ def generate_pydot_graph(root, visibility_level, collapse_decorators):
         root (:class:`~py_trees.behaviour.Behaviour`): the root of a tree, or subtree
         visibility_level (:class`~py_trees.common.VisibilityLevel`): collapse subtrees at or under this level
         collapse_decorators (:obj:`bool`): only show the decorator (not the child)
+        with_class_names: (:obj:`bool`): print the class information for each behaviour in each node
 
     Returns:
         pydot.Dot: graph
     """
-    def get_node_attributes(node, visibility_level):
+    def get_node_attributes(node):
         blackbox_font_colours = {common.BlackBoxLevel.DETAIL: "dodgerblue",
                                  common.BlackBoxLevel.COMPONENT: "lawngreen",
                                  common.BlackBoxLevel.BIG_PICTURE: "white"
@@ -253,15 +257,34 @@ def generate_pydot_graph(root, visibility_level, collapse_decorators):
             attributes = (attributes[0], 'gray20', blackbox_font_colours[node.blackbox_level])
         return attributes
 
-    fontsize = 11
+    def get_node_label(node_name, behaviour):
+        """
+        This extracts a more detailed string (when applicable) to append to
+        that which will be used for the node name.
+        """
+        node_label = node_name
+        if behaviour.verbose_info_string():
+            node_label += "\n{}".format(behaviour.verbose_info_string())
+        if with_qualified_names:
+            node_label += "\n({})".format(utilities.get_fully_qualified_name(behaviour))
+        return node_label
+
+    fontsize = 9
     graph = pydot.Dot(graph_type='digraph')
     graph.set_name("pastafarianism")  # consider making this unique to the tree sometime, e.g. based on the root name
     # fonts: helvetica, times-bold, arial (times-roman is the default, but this helps some viewers, like kgraphviewer)
-    graph.set_graph_defaults(fontname='times-roman')
+    graph.set_graph_defaults(fontname='times-roman', splines='curved')
     graph.set_node_defaults(fontname='times-roman')
     graph.set_edge_defaults(fontname='times-roman')
-    (node_shape, node_colour, node_font_colour) = get_node_attributes(root, visibility_level)
-    node_root = pydot.Node(root.name, shape=node_shape, style="filled", fillcolor=node_colour, fontsize=fontsize, fontcolor=node_font_colour)
+    (node_shape, node_colour, node_font_colour) = get_node_attributes(root)
+    node_root = pydot.Node(
+        root.name,
+        label=get_node_label(root.name, root),
+        shape=node_shape,
+        style="filled",
+        fillcolor=node_colour,
+        fontsize=fontsize,
+        fontcolor=node_font_colour)
     graph.add_node(node_root)
     names = [root.name]
 
@@ -270,17 +293,27 @@ def generate_pydot_graph(root, visibility_level, collapse_decorators):
             return
         if visibility_level < root.blackbox_level:
             for c in root.children:
-                (node_shape, node_colour, node_font_colour) = get_node_attributes(c, visibility_level)
-                proposed_dot_name = c.name
-                while proposed_dot_name in names:
-                    proposed_dot_name = proposed_dot_name + "*"
-                names.append(proposed_dot_name)
-                node = pydot.Node(proposed_dot_name, shape=node_shape, style="filled", fillcolor=node_colour, fontsize=fontsize, fontcolor=node_font_colour)
+                (node_shape, node_colour, node_font_colour) = get_node_attributes(c)
+                node_name = c.name
+                while node_name in names:
+                    node_name += "*"
+                names.append(c.name)
+                node = pydot.Node(
+                    node_name,
+                    label=get_node_label(node_name, c),
+                    shape=node_shape,
+                    style="filled",
+                    fillcolor=node_colour,
+                    fontsize=fontsize,
+                    fontcolor=node_font_colour,
+                    # tooltip="foo",
+                    # xlabel="dunders"  # shows up like a stray cat somewhere to the topleft of the node in dot, png's
+                )
                 graph.add_node(node)
-                edge = pydot.Edge(root_dot_name, proposed_dot_name)
+                edge = pydot.Edge(root_dot_name, node_name)
                 graph.add_edge(edge)
                 if c.children != []:
-                    add_edges(c, proposed_dot_name, visibility_level, collapse_decorators)
+                    add_edges(c, node_name, visibility_level, collapse_decorators)
 
     add_edges(root, root.name, visibility_level, collapse_decorators)
     return graph
@@ -305,7 +338,8 @@ def render_dot_tree(root: behaviour.Behaviour,
                     visibility_level: common.VisibilityLevel=common.VisibilityLevel.DETAIL,
                     collapse_decorators: bool=False,
                     name: str=None,
-                    target_directory: str=os.getcwd()):
+                    target_directory: str=os.getcwd(),
+                    with_qualified_names: bool=False):
     """
     Render the dot tree to .dot, .svg, .png. files in the current
     working directory. These will be named with the root behaviour name.
@@ -315,6 +349,8 @@ def render_dot_tree(root: behaviour.Behaviour,
         visibility_level (:class`~py_trees.common.VisibilityLevel`): collapse subtrees at or under this level
         collapse_decorators (:obj:`bool`): only show the decorator (not the child)
         name (:obj:`str`): name to use for the created files (defaults to the root behaviour name)
+        target_directory (:obj:`str`): default is to use the current working directory, set this to redirect elsewhere
+        with_qualified_names (:obj:`bool`): print the class names of each behaviour in the dot node
 
     Example:
 
@@ -338,7 +374,7 @@ def render_dot_tree(root: behaviour.Behaviour,
         A good practice is to provide a command line argument for optional rendering of a program so users
         can quickly visualise what tree the program will execute.
     """
-    graph = generate_pydot_graph(root, visibility_level, collapse_decorators)
+    graph = generate_pydot_graph(root, visibility_level, collapse_decorators, with_qualified_names=with_qualified_names)
     filename_wo_extension_to_convert = root.name if name is None else name
     filename_wo_extension = utilities.get_valid_filename(filename_wo_extension_to_convert)
     filenames = {}

--- a/py_trees/idioms.py
+++ b/py_trees/idioms.py
@@ -27,7 +27,12 @@ from . import decorators
 ##############################################################################
 
 
-def pick_up_where_you_left_off(name, tasks):
+def pick_up_where_you_left_off(
+        name="Pickup Where You Left Off Idiom",
+        tasks=[behaviours.Dummy(name="Dummy1"),  # dummy behaviours to enable dot rendering with py-trees-render
+               behaviours.Dummy(name="Dummy1")
+               ]
+        ):
     """
     Rudely interrupted while enjoying a sandwich, a caveman (just because
     they wore loincloths does not mean they were not civilised), picks
@@ -91,7 +96,10 @@ def pick_up_where_you_left_off(name, tasks):
     return root
 
 
-def oneshot(name, variable_name, behaviour, policy=common.OneShotPolicy.ON_SUCCESSFUL_COMPLETION):
+def oneshot(name="OneShot Idiom",
+            variable_name="oneshot",
+            behaviour=behaviours.Dummy(),  # dummy behaviour to enable dot rendering with py-trees-render
+            policy=common.OneShotPolicy.ON_SUCCESSFUL_COMPLETION):
     """
     Ensure that a particular pattern is executed through to
     completion just once. Thereafter it will just rebound with success.

--- a/py_trees/programs/render.py
+++ b/py_trees/programs/render.py
@@ -88,6 +88,7 @@ def command_line_argument_parser():
                         help='visibility level')
     parser.add_argument('-n', '--name', default=None, help='name to use for the created files (defaults to the root behaviour name)')
     parser.add_argument('-k', '--kwargs', default="{}", type=json.loads, help='dictionary of keyword arguments to the method')
+    parser.add_argument('-v', '--verbose', default=False, action='store_true', help="embellish each node in the dot graph with extra information")
     return parser
 
 
@@ -112,4 +113,9 @@ def main():
 
     # TODO figure out how to insert keyword arguments
     root = method_itself(**(args.kwargs))
-    py_trees.display.render_dot_tree(root, args.enum_level, args.name)
+    py_trees.display.render_dot_tree(
+        root,
+        args.enum_level,
+        args.name,
+        with_qualified_names=args.verbose
+    )

--- a/py_trees/utilities.py
+++ b/py_trees/utilities.py
@@ -19,7 +19,7 @@ import os
 import re
 
 ##############################################################################
-# System OS Tools
+# System Tools
 ##############################################################################
 
 
@@ -49,6 +49,7 @@ def which(program):
 
     return None
 
+
 def get_valid_filename(s: str) -> str:
     """
     Return the given string converted to a string that can be used for a clean
@@ -70,13 +71,37 @@ def get_valid_filename(s: str) -> str:
     s = str(s).strip().lower().replace(' ', '_').replace('\n', '_')
     return re.sub(r'(?u)[^-\w.]', '', s)
 
+
+def get_fully_qualified_name(instance: object) -> str:
+    """
+    Get at the fully qualified name of an object, e.g.
+    an instance of a :class:`~py_trees.composites.Sequence`
+    becomes 'py_trees.composites.Sequence'.
+
+    Args:
+        instance (:obj:`object`): an instance of any class
+
+    Returns:
+        :obj:`str`: the fully qualified name
+    """
+    module = instance.__class__.__module__
+    # if there is no module, it will report builtin, get that
+    # string via what should remain constant, the 'str' class
+    # and check against that.
+    builtin = str.__class__.__module__
+    if module is None or module == builtin:
+        return instance.__class__.__name__
+    else:
+        return module + '.' + instance.__class__.__name__
+
 ##############################################################################
 # Python Helpers
 ##############################################################################
 
+
 def static_variables(**kwargs):
     """
-    This is a decorator that can be used with python methods to attach 
+    This is a decorator that can be used with python methods to attach
     initialised static variables to the method.
 
     .. code-block:: python

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 import os
 
 # You need install_requires if you don't have a ROS environment
-install_requires = [ # ] if os.environ.get('AMENT_PREFIX_PATH') else [
+install_requires = [  # ] if os.environ.get('AMENT_PREFIX_PATH') else [
     # build
     'setuptools',
     # runtime
@@ -12,7 +12,7 @@ install_requires = [ # ] if os.environ.get('AMENT_PREFIX_PATH') else [
     'pydot'
 ]
 
-tests_require=['nose', 'pydot', 'pytest', 'flake8', 'yanc', 'nose-htmloutput']
+tests_require = ['nose', 'pydot', 'pytest', 'flake8', 'yanc', 'nose-htmloutput']
 
 extras_require = {} if os.environ.get('AMENT_PREFIX_PATH') else {
     'test': tests_require,
@@ -58,6 +58,7 @@ d = setup(
     tests_require=tests_require,
     entry_points={
          'console_scripts': [
+             'py-trees-render = py_trees.programs.render:main',
              'py-trees-demo-action-behaviour = py_trees.demos.action:main',
              'py-trees-demo-behaviour-lifecycle = py_trees.demos.lifecycle:main',
              'py-trees-demo-blackboard = py_trees.demos.blackboard:main',

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -36,18 +36,6 @@ class DummyDecorator(py_trees.decorators.Decorator):
 ##############################################################################
 
 
-def test_set_name():
-    console.banner("Set Name")
-    child = py_trees.behaviours.Success(name="Woohoo")
-    named_decorator = DummyDecorator(name="Foo", child=child)
-    no_named_decorator = DummyDecorator(child=child)
-    print("\n--------- Assertions ---------\n")
-    print("named_decorator.name == Foo")
-    assert(named_decorator.name == "Foo")
-    print("no_named_decorator.name == DummyDecorator\\n[Woohoo]")
-    assert(no_named_decorator.name == "DummyDecorator\n[Woohoo]")
-
-
 def test_invalid_child():
     console.banner("Invalid Child")
     print("\n--------- Assertions ---------\n")

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -25,6 +25,19 @@ def test_valid_filenames():
         " Leading Space": "leading_space",
         "Trailing Space ": "trailing_space"
     }
+    print(console.green + "------------------ Assertions ------------------\n" + console.reset)
     for name, expected_name in names.items():
         print(console.cyan + repr(name) + ": " + console.yellow + expected_name + " [" + utilities.get_valid_filename(name) + "]" + console.reset)
         assert(utilities.get_valid_filename(name) == expected_name)
+
+
+def test_get_fully_qualified_name():
+    console.banner("Fully Qualified Names")
+    pairs = {
+        "py_trees.behaviour.Behaviour": py_trees.behaviour.Behaviour(),
+        "py_trees.decorators.Inverter": py_trees.decorators.Inverter(child=py_trees.behaviours.Success())
+    }
+    print(console.green + "------------------ Assertions ------------------\n" + console.reset)
+    for expected_name, object_instance in pairs.items():
+        print(console.cyan + expected_name + console.white + " == " + console.yellow + utilities.get_fully_qualified_name(object_instance) + console.reset)
+        assert(expected_name == utilities.get_fully_qualified_name(object_instance))


### PR DESCRIPTION
Resolves #120.

### Dot Graphs

**Parallel Policies**

Always shown, but enabled by a generic mechanism for any class, the `Behaviour.verbose_info_string()` method which, unless overridden, returns the empty string so nothing changes.

![parallel](https://user-images.githubusercontent.com/687378/51297382-0d720d80-19ee-11e9-950b-ed7dfb076e42.png)

**Fully Qualified Names**

An optional flag to `render_dot_tree()` and will print class information in each of the nodes. This will blow up the dot graph somewhat, but can be useful.

[Click to Expand]

![pick_up_where_you_left_off](https://user-images.githubusercontent.com/687378/51296208-fd0b6400-19e8-11e9-9389-b3b7b9157255.png)

### Incidentals

**py-trees-render**

This got lost in the transition to python3. It's now re-enabled and takes the --verbose flag to get the fully qualified names.

```
py-trees-render --verbose py_trees.idioms.oneshot
```

![oneshot_idiom](https://user-images.githubusercontent.com/687378/51297139-23cb9980-19ed-11e9-8cbc-1bbd51fb4c46.png)

**Decorator Names Simplified**

I was appending the child name to the decorator. Removed because it's fairly verbose and only necessary if you're collapsing the children in a dot graph. If interested in those, people will probably set decent names anyway.

**AUTO_GENERATED**

These go all the way back to `py_trees.behaviour.Behaviour` now.

FYI @naveedhd 