### PR TITLE
[visitors] winds_of_change visitor, with logging demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ tests/.README.md.html
 nosetests.html
 eclipse
 *.vscode
+dump.json
 

--- a/doc/demos.rst
+++ b/doc/demos.rst
@@ -83,6 +83,22 @@ py-trees-demo-dot-graphs
    :linenos:
    :caption: py_trees/demos/dot_graphs.py
 
+.. _py-trees-demo-logging-program:
+
+py-trees-demo-logging
+---------------------
+
+.. automodule:: py_trees.demos.logging
+    :members:
+    :special-members:
+    :show-inheritance:
+    :synopsis: demo tree logging to json files
+
+.. literalinclude:: ../py_trees/demos/logging.py
+   :language: python
+   :linenos:
+   :caption: py_trees/demos/logging.py
+
 .. _py-trees-demo-selector-program:
 
 py-trees-demo-selector

--- a/py_trees/demos/logging.py
+++ b/py_trees/demos/logging.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+#
+# License: BSD
+#   https://raw.githubusercontent.com/stonier/py_trees/devel/LICENSE
+#
+##############################################################################
+# Documentation
+##############################################################################
+
+"""
+.. argparse::
+   :module: py_trees.demos.stewardship
+   :func: command_line_argument_parser
+   :prog: py-trees-demo-tree-stewardship
+
+.. graphviz:: dot/stewardship.dot
+
+.. image:: images/tree_stewardship.gif
+"""
+
+##############################################################################
+# Imports
+##############################################################################
+
+import argparse
+import functools
+import py_trees
+import sys
+import time
+
+import py_trees.console as console
+
+##############################################################################
+# Classes
+##############################################################################
+
+
+def description(root):
+    content = "A demonstration of logging with trees.\n\n"
+    content += "Trees will typically spend much time ticking without\n"
+    content += "a significant change that is relevant for the purposes\n"
+    content += "of monitoring or debugging. In this demo a significant\n"
+    content += "change is defined as one for which the visited path (i.e.\n"
+    content += "the decision making) has changed. Here a visitor is used\n"
+    content += "to trace the visited path from tick to tick, raising a flag\n"
+    content += "if the path changes. This flag is caught and prompts a\n"
+    content += "post-tick handler to commence logging for that tick.\n"
+    content += "\n"
+    if py_trees.console.has_colours:
+        banner_line = console.green + "*" * 79 + "\n" + console.reset
+        s = "\n"
+        s += banner_line
+        s += console.bold_white + "Trees".center(79) + "\n" + console.reset
+        s += banner_line
+        s += "\n"
+        s += content
+        s += "\n"
+        s += banner_line
+    else:
+        s = content
+    return s
+
+
+def epilog():
+    if py_trees.console.has_colours:
+        return console.cyan + "And his noodly appendage reached forth to tickle the blessed...\n" + console.reset
+    else:
+        return None
+
+
+def command_line_argument_parser():
+    parser = argparse.ArgumentParser(description=description(create_tree()),
+                                     epilog=epilog(),
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-r', '--render', action='store_true', help='render dot tree to file')
+    group.add_argument('-i', '--interactive', action='store_true', help='pause and wait for keypress at each tick')
+    return parser
+
+
+def pre_tick_handler(behaviour_tree):
+    """
+    This prints a banner and will run immediately before every tick of the tree.
+
+    Args:
+        behaviour_tree (:class:`~py_trees.trees.BehaviourTree`): the tree custodian
+
+    """
+    print("\n--------- Run %s ---------\n" % behaviour_tree.count)
+
+
+def post_tick_handler(snapshot_visitor, behaviour_tree):
+    """
+    Prints an ascii tree with the current snapshot status.
+    """
+    print("\n" + py_trees.display.ascii_tree(behaviour_tree.root,
+                                             snapshot_information=snapshot_visitor))
+
+
+def create_tree():
+    every_n_success = py_trees.behaviours.SuccessEveryN("EveryN", 5)
+    sequence = py_trees.composites.Sequence(name="Sequence")
+    guard = py_trees.behaviours.Success("Guard")
+    periodic_success = py_trees.behaviours.Periodic("Periodic", 3)
+    finisher = py_trees.behaviours.Success("Finisher")
+    sequence.add_child(guard)
+    sequence.add_child(periodic_success)
+    sequence.add_child(finisher)
+    sequence.blackbox_level = py_trees.common.BlackBoxLevel.COMPONENT
+    idle = py_trees.behaviours.Success("Idle")
+    root = py_trees.composites.Selector(name="Demo Tree")
+    root.add_child(every_n_success)
+    root.add_child(sequence)
+    root.add_child(idle)
+    return root
+
+
+##############################################################################
+# Main
+##############################################################################
+
+def main():
+    """
+    Entry point for the demo script.
+    """
+    args = command_line_argument_parser().parse_args()
+    py_trees.logging.level = py_trees.logging.Level.DEBUG
+    tree = create_tree()
+    print(description(tree))
+
+    ####################
+    # Rendering
+    ####################
+    if args.render:
+        py_trees.display.render_dot_tree(tree)
+        sys.exit()
+
+    ####################
+    # Tree Stewardship
+    ####################
+    behaviour_tree = py_trees.trees.BehaviourTree(tree)
+    behaviour_tree.add_pre_tick_handler(pre_tick_handler)
+    behaviour_tree.visitors.append(py_trees.visitors.DebugVisitor())
+    snapshot_visitor = py_trees.visitors.SnapshotVisitor()
+    behaviour_tree.add_post_tick_handler(functools.partial(post_tick_handler, snapshot_visitor))
+    behaviour_tree.visitors.append(snapshot_visitor)
+    behaviour_tree.setup(timeout=15)
+
+    ####################
+    # Tick Tock
+    ####################
+    if args.interactive:
+        py_trees.console.read_single_keypress()
+    while True:
+        try:
+            behaviour_tree.tick()
+            if args.interactive:
+                py_trees.console.read_single_keypress()
+            else:
+                time.sleep(0.5)
+        except KeyboardInterrupt:
+            break
+    print("\n")

--- a/py_trees/tests.py
+++ b/py_trees/tests.py
@@ -41,6 +41,8 @@ def tick_tree(tree,
               ):
     print("\n================== Iteration {}-{} ==================\n".format(from_tick, to_tick))
     for i in range(from_tick, to_tick + 1):
+        for visitor in visitors:
+            visitor.initialise()
         print(("\n--------- Run %s ---------\n" % i))
         for node in tree.tick():
             for visitor in visitors:

--- a/py_trees/visitors.py
+++ b/py_trees/visitors.py
@@ -125,3 +125,47 @@ class SnapshotVisitor(VisitorBase):
         self.nodes[behaviour.id] = behaviour.status
         if behaviour.status == common.Status.RUNNING:
             self.running_nodes.append(behaviour.id)
+
+
+class ChangeVisitor(VisitorBase):
+    """
+    Visits the ticked part of a tree, checking off the status against the set of status
+    results recorded in the previous tick. If there has been a change, it flags it.
+    This is useful for determining when to trigger, e.g. logging.
+
+    Attributes:
+        changed (Bool): flagged if there is a difference in the visited path or :class:`~py_trees.common.Status` of any behaviour on the path
+        ticked_nodes (dict): dictionary of behaviour id (uuid.UUID) and status (:class:`~py_trees.common.Status`) pairs from the current tick
+        previously_ticked+nodes (dict): dictionary of behaviour id (uuid.UUID) and status (:class:`~py_trees.common.Status`) pairs from the previous tick
+        running_nodes([uuid.UUID]): list of id's for behaviours which were traversed in the current tick
+        previously_running_nodes([uuid.UUID]): list of id's for behaviours which were traversed in the last tick
+
+    .. seealso::
+
+        TODO: Some demo
+    """
+    def __init__(self):
+        super().__init__(full=False)
+        self.changed = False
+        self.ticked_nodes = {}
+        self.previously_ticked_nodes = {}
+
+    def initialise(self):
+        """
+        Switch running to previously running and then reset all other variables. This should
+        get called before a tree ticks.
+        """
+        self.changed = False
+
+    def run(self, behaviour):
+        """
+        This method gets run as each behaviour is ticked. Catch the id and status and store it.
+        Additionally add it to the running list if it is :data:`~py_trees.common.Status.RUNNING`.
+
+        Args:
+            behaviour (:class:`~py_trees.behaviour.Behaviour`): behaviour that is ticking
+        """
+        if self.ticked_nodes != self.previously_ticked_nodes:
+            self.changed = True
+        self.previously_ticked_nodes = self.ticked_nodes
+        self.ticked_nodes = {}

--- a/py_trees/visitors.py
+++ b/py_trees/visitors.py
@@ -127,7 +127,7 @@ class SnapshotVisitor(VisitorBase):
             self.running_nodes.append(behaviour.id)
 
 
-class ChangeVisitor(VisitorBase):
+class WindsOfChangeVisitor(VisitorBase):
     """
     Visits the ticked part of a tree, checking off the status against the set of status
     results recorded in the previous tick. If there has been a change, it flags it.
@@ -140,9 +140,7 @@ class ChangeVisitor(VisitorBase):
         running_nodes([uuid.UUID]): list of id's for behaviours which were traversed in the current tick
         previously_running_nodes([uuid.UUID]): list of id's for behaviours which were traversed in the last tick
 
-    .. seealso::
-
-        TODO: Some demo
+    .. seealso:: The :ref:`py-trees-demo-logging-program` program demonstrates use of this visitor to trigger logging of a tree serialisation.
     """
     def __init__(self):
         super().__init__(full=False)
@@ -156,6 +154,8 @@ class ChangeVisitor(VisitorBase):
         get called before a tree ticks.
         """
         self.changed = False
+        self.previously_ticked_nodes = self.ticked_nodes
+        self.ticked_nodes = {}
 
     def run(self, behaviour):
         """
@@ -165,7 +165,9 @@ class ChangeVisitor(VisitorBase):
         Args:
             behaviour (:class:`~py_trees.behaviour.Behaviour`): behaviour that is ticking
         """
-        if self.ticked_nodes != self.previously_ticked_nodes:
+        self.ticked_nodes[behaviour.id] = behaviour.status
+        try:
+            if self.ticked_nodes[behaviour.id] != self.previously_ticked_nodes[behaviour.id]:
+                self.changed = True
+        except KeyError:
             self.changed = True
-        self.previously_ticked_nodes = self.ticked_nodes
-        self.ticked_nodes = {}

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ d = setup(
              'py-trees-demo-blackboard = py_trees.demos.blackboard:main',
              'py-trees-demo-context-switching = py_trees.demos.context_switching:main',
              'py-trees-demo-dot-graphs = py_trees.demos.dot_graphs:main',
+             'py-trees-demo-logging = py_trees.demos.logging:main',
              'py-trees-demo-pick-up-where-you-left-off = py_trees.demos.pick_up_where_you_left_off:main',
              'py-trees-demo-selector = py_trees.demos.selector:main',
              'py-trees-demo-sequence = py_trees.demos.sequence:main',

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#
+# License: BSD
+#   https://raw.githubusercontent.com/stonier/py_trees/devel/LICENSE
+#
+
+##############################################################################
+# Imports
+##############################################################################
+
+import os
+
+import nose.tools
+
+import py_trees
+import py_trees.console as console
+
+##############################################################################
+# Logging Level
+##############################################################################
+
+py_trees.logging.level = py_trees.logging.Level.DEBUG
+logger = py_trees.logging.Logger("Nosetest")
+
+
+##############################################################################
+# Classes
+##############################################################################
+
+##############################################################################
+# Tests
+##############################################################################
+
+
+def test_winds_of_change():
+    console.banner("Winds of Change")
+
+    root = py_trees.composites.Selector(name='Selector')
+    a = py_trees.behaviours.Count(name="A")
+    b = py_trees.behaviours.Count(name="B")
+    c = py_trees.behaviours.Count(name="C", fail_until=0, running_until=3, success_until=15)
+    root.add_child(a)
+    root.add_child(b)
+    root.add_child(c)
+    py_trees.display.print_ascii_tree(root, 0)
+
+    debug_visitor = py_trees.visitors.DebugVisitor()
+    snapshot_visitor = py_trees.visitors.SnapshotVisitor()
+    winds_of_change_visitor = py_trees.visitors.WindsOfChangeVisitor()
+
+    for i, result in zip(range(1, 5), [True, False, False, True]):
+        py_trees.tests.tick_tree(
+            root, i, i,
+            visitors=[debug_visitor,
+                      snapshot_visitor,
+                      winds_of_change_visitor],
+            print_snapshot=True
+        )
+        print("--------- Assertions ---------\n")
+        print("winds_of_change_visitor.changed == {}".format(result))
+        assert(winds_of_change_visitor.changed is result)
+
+    print("Done")

--- a/virtualenv.bash
+++ b/virtualenv.bash
@@ -78,7 +78,6 @@ VERSION="--python=/usr/bin/python3"
 if [ "${VIRTUAL_ENV}" == "" ]; then
   workon ${NAME}
   result=$?
-  echo $result
   if [ $result -eq 1 ]; then
     mkvirtualenv ${VERSION} ${NAME}
   fi


### PR DESCRIPTION
Resolves #152.

* [x] a change visitor (need a cool name!) that acts on status changes
* [ ] ~~update `BehaviourTree` to store visitors in a dict with a keyword identifier, not a list~~
* [x] tests
* [x] demo and docs

The second wasn't necessary since `functools.partial` is sufficient. Subsequently, this can be a patch version improvement.