### PR TITLE
fixes doc warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 
 0.5.12 (2019-02-13)
-------------------
+-------------------
 [decorators] default option for collapsing decorators (resolves py_trees_ros bug)
 
 0.5.11 (2019-02-13)

--- a/py_trees/decorators.py
+++ b/py_trees/decorators.py
@@ -109,6 +109,7 @@ class Decorator(behaviour.Behaviour):
         """
         A decorator's tick is exactly the same as a normal proceedings for
         a Behaviour's tick except that it also ticks the decorated child node.
+
         Yields:
             :class:`~py_trees.behaviour.Behaviour`: a reference to itself or one of its children
         """

--- a/py_trees/utilities.py
+++ b/py_trees/utilities.py
@@ -57,11 +57,13 @@ def static_variables(**kwargs):
     """
     This is a decorator that can be used with python methods to attach 
     initialised static variables to the method.
-     .. code-block:: python
+
+    .. code-block:: python
+
         @static_variables(counter=0)
         def foo():
             foo.counter += 1
-            print("Counter: {}".formta(foo.counter))
+            print("Counter: {}".format(foo.counter))
     """
     def decorate(func):
         for k in kwargs:


### PR DESCRIPTION
resolves the doc warnings in this [build](http://build.ros.org/job/Kdoc__py_trees__ubuntu_xenial_amd64/9/console).

not sure if this solves the build failing issue.