### PR TITLE
[decorators] timeout that respects the childs last tick

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Release Notes
 
 Forthcoming
 -----------
+* [decorators] fix timeout bug that doesn't respect a child's last tick
 
 1.0.4 (2019-02-26)
 ------------------

--- a/py_trees/decorators.py
+++ b/py_trees/decorators.py
@@ -187,7 +187,7 @@ class Timeout(Decorator):
         """
         Reset the feedback message and finish time on behaviour entry.
         """
-        self.finish_time = time.time() + self.duration
+        self.finish_time = time.monotonic() + self.duration
         self.feedback_message = ""
 
     def update(self):
@@ -195,7 +195,7 @@ class Timeout(Decorator):
         Terminate the child and return :data:`~py_trees.common.Status.FAILURE`
         if the timeout is exceeded.
         """
-        current_time = time.time()
+        current_time = time.monotonic()
         if self.decorated.status == common.Status.RUNNING and current_time > self.finish_time:
             self.feedback_message = "timed out"
             self.logger.debug("{}.update() {}".format(self.__class__.__name__, self.feedback_message))
@@ -203,11 +203,11 @@ class Timeout(Decorator):
             self.decorated.stop(common.Status.INVALID)
             return common.Status.FAILURE
         if self.decorated.status == common.Status.RUNNING:
-            self.feedback_message = self.decorated.feedback_message + " [time remaining: {}s]".format(
+            self.feedback_message = "time still ticking ... [remaining: {}s]".format(
                 self.finish_time - current_time
             )
         else:
-            self.feedback_message = self.decorated.feedback_message
+            self.feedback_message = "child finished before timeout triggered"
         return self.decorated.status
 
 

--- a/py_trees/decorators.py
+++ b/py_trees/decorators.py
@@ -196,15 +196,18 @@ class Timeout(Decorator):
         if the timeout is exceeded.
         """
         current_time = time.time()
-        if current_time > self.finish_time:
+        if self.decorated.status == common.Status.RUNNING and current_time > self.finish_time:
             self.feedback_message = "timed out"
             self.logger.debug("{}.update() {}".format(self.__class__.__name__, self.feedback_message))
             # invalidate the decorated (i.e. cancel it), could also put this logic in a terminate() method
             self.decorated.stop(common.Status.INVALID)
             return common.Status.FAILURE
-        # Don't show the time remaining, that will change the message every tick and make the tree hard to
-        # debug since it will record a continuous stream of events
-        self.feedback_message = self.decorated.feedback_message + " [timeout: {}]".format(self.finish_time)
+        if self.decorated.status == common.Status.RUNNING:
+            self.feedback_message = self.decorated.feedback_message + " [time remaining: {}s]".format(
+                self.finish_time - current_time
+            )
+        else:
+            self.feedback_message = self.decorated.feedback_message
         return self.decorated.status
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -339,6 +339,34 @@ def test_timeout():
     print("failure.status == py_trees.common.Status.FAILURE")
     assert(failure.status == py_trees.common.Status.FAILURE)
 
+    # test that it succeeds if child succeeds on last tick
+    count = py_trees.behaviours.Count(
+        name="Count",
+        fail_until=0,
+        running_until=1,
+        success_until=10,
+        reset=False
+    )
+    timeout = py_trees.decorators.Timeout(child=count, duration=0.1)
+    py_trees.display.print_ascii_tree(timeout)
+
+    py_trees.tests.tick_tree(timeout, 1, 1, visitors=[visitor])
+
+    print("\n--------- Assertions ---------\n")
+    print("timeout.status == py_trees.common.Status.RUNNING")
+    assert(timeout.status == py_trees.common.Status.RUNNING)
+    print("count.status == py_trees.common.Status.RUNNING")
+    assert(count.status == py_trees.common.Status.RUNNING)
+
+    time.sleep(0.2)  # go past the duration
+    py_trees.tests.tick_tree(timeout, 2, 2, visitors=[visitor])
+
+    print("\n--------- Assertions ---------\n")
+    print("timeout.status == py_trees.common.Status.SUCCESS")
+    assert(timeout.status == py_trees.common.Status.SUCCESS)
+    print("count.status == py_trees.common.Status.SUCCESS")
+    assert(count.status == py_trees.common.Status.SUCCESS)
+
 
 def test_condition():
     console.banner("Condition")


### PR DESCRIPTION
Make sure the timeout respects the childs last tick. If you do not, the underlying subsystem might be already off and pursuing some kind of action because the child succeeded but is now inconsistent because the timeout masks this.

Exemplar problem:

* Tree configured to tick periodically every 1.0s
* Timeout configured with duration of 5.0 seconds
* Tree starts ticking at global time 0.0
* Tree ticks at global time 1.0
* Decorator initialised, child is running 
* Tree ticks through global time 2.0->4.0
* Child is potentially ready to switch to SUCCESS at 4.1 seconds
* Tree ticks at global time 5.0
* Child returns SUCCESS, but timeout is triggered, FAILURE is returned

This is logically incorrect and will be especially obvious if, for example, the underlying child behaviour is connected to an action which actually did finish at global time 4.1.