### PR TITLE
Add labels for some sections

### DIFF
--- a/doc/background.rst
+++ b/doc/background.rst
@@ -26,6 +26,8 @@ Some standout features of behaviour trees that makes them very attractive:
 * **Simplicity** - very few core components, making it easy for designers to work with it
 * **Dynamic** - change the graph on the fly, between ticks or from parent behaviours themselves
 
+.. _motivation-section:
+
 Motivation
 ----------
 
@@ -45,6 +47,8 @@ implementations happen within the closed doors of gaming/robot companies.
 the developments of the last ten years from an industry expert. It also
 walks you through a simple c++ implementation. His advice? If you can't find one that fits, roll your own.
 It is relatively simple and this way you can flexibly cater for your own needs.
+
+.. _design-section:
 
 Design
 ------
@@ -69,6 +73,7 @@ that python has to offer. Some design constraints that have been assumed to enab
 
 .. hint:: A c++ version is feasible and may come forth if there's a need..
 
+.. _readings-section:
 
 Readings
 --------

--- a/doc/behaviours.rst
+++ b/doc/behaviours.rst
@@ -1,3 +1,5 @@
+.. _behaviours-section:
+
 Behaviours
 ==========
 
@@ -17,6 +19,8 @@ Behaviours in py_trees are created by subclassing the
    :language: python
    :linenos:
 
+.. _lifecycle-section:
+
 Lifecycle
 ---------
 
@@ -35,6 +39,8 @@ Important points to focus on:
   :meth:`~py_trees.demos.lifecycle.Counter.terminate()` methods.
 * The parent :meth:`~py_trees.behaviour.Behaviour.tick()` method always calls update()
 * The :meth:`~py_trees.demos.lifecycle.Counter.update()` method is responsible for deciding the behaviour :ref:`status-section`.
+
+.. _initialisation-section:
 
 Initialisation
 --------------
@@ -84,6 +90,8 @@ The ``update()`` method must return one of ``RUNNING``. ``SUCCESS`` or ``FAILURE
 status of ``INVALID`` is the initial default and ordinarily automatically set by other
 mechansims (e.g. when a higher priority behaviour cancels the currently selected one).
 
+.. _feedback-message-section:
+
 Feedback Message
 ----------------
 
@@ -115,6 +123,8 @@ Avoid updating it with a feedback message at every tick with updated plan
 details. Instead, update the message whenever a significant change
 occurs - e.g. when the previous plan is re-planned or pre-empted.
 
+.. _loggers-section:
+
 Loggers
 -------
 
@@ -123,6 +133,8 @@ for anything heavier than debugging simple examples. This kind of logging
 tends to get rather heavy and requires a lot of filtering to find the points
 of change that you are interested in (see comments about the feedback
 messages above).
+
+.. _complex-example-section:
 
 Complex Example
 ---------------

--- a/doc/composites.rst
+++ b/doc/composites.rst
@@ -1,3 +1,5 @@
+.. _composites-section:
+
 Composites
 ==========
 
@@ -9,11 +11,15 @@ composite's methods, visit the :ref:`py-trees-composites-module` module api docu
 
 .. tip:: First time through, make sure to follow the link through to relevant demo programs.
 
+.. _sequence-section:
+
 Sequence
 --------
 
 .. autoclass:: py_trees.composites.Sequence
     :noindex:
+
+.. _selector-section:
 
 Selector
 --------
@@ -21,11 +27,15 @@ Selector
 .. autoclass:: py_trees.composites.Selector
     :noindex:
 
+.. _chooser-section:
+
 Chooser
 -------
 
 .. autoclass:: py_trees.composites.Chooser
     :noindex:
+
+.. _parallel-section:
 
 Parallel
 --------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -307,4 +307,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-# intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}

--- a/doc/demos.rst
+++ b/doc/demos.rst
@@ -147,6 +147,8 @@ py-trees-demo-tree-stewardship
    :linenos:
    :caption: py_trees/demos/stewardship.py
 
+.. _py-trees-demo-pick-up-where-you-left-off-program:
+
 py-trees-demo-pick-up-where-you-left-off
 ----------------------------------------
 

--- a/doc/idioms.rst
+++ b/doc/idioms.rst
@@ -1,3 +1,5 @@
+.. _idioms-section:
+
 Idioms
 ======
 
@@ -20,11 +22,15 @@ composite's methods, visit the :ref:`py-trees-idioms-module` module api document
 
 .. tip:: First time through, make sure to follow the link through to relevant demo programs.
 
+.. _oneshot-section:
+
 Oneshot
 -------
 
 .. automethod:: py_trees.idioms.oneshot
     :noindex:
+
+.. _pick-up-where-you-left-off-section:
 
 Pickup Where You left Off
 -------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,6 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. _index-section:
+
 Py Trees
 ========
 

--- a/doc/terminology.rst
+++ b/doc/terminology.rst
@@ -1,3 +1,5 @@
+.. _terminology-section:
+
 Terminology
 ===========
 

--- a/doc/trees.rst
+++ b/doc/trees.rst
@@ -1,14 +1,20 @@
+.. _trees-section:
+
 Trees
 =====
 
 .. automodule:: py_trees.trees
     :noindex:
 
+.. _behaviour-tree-section:
+
 The Behaviour Tree
 ------------------
 
 .. autoclass:: py_trees.trees.BehaviourTree
     :noindex:
+
+.. _skeleton-section:
 
 Skeleton
 --------
@@ -23,6 +29,8 @@ or indefinitely and use the :meth:`~py_trees.trees.BehaviourTree.interrupt` meth
 
 or create your own loop and tick at your own leisure with
 the :meth:`~py_trees.trees.BehaviourTree.tick` method.
+
+.. _pre-post-tick-handlers-section:
 
 Pre/Post Tick Handlers
 ----------------------
@@ -58,6 +66,7 @@ The relevant code:
    :lines: 135-136
    :caption: pre-tick-handler-adding
 
+.. _visitors-section:
 
 Visitors
 --------

--- a/doc/visualisation.rst
+++ b/doc/visualisation.rst
@@ -1,8 +1,12 @@
+.. _visualisation-section:
+
 Visualisation
 =============
 
 .. automodule:: py_trees.display
     :noindex:
+
+.. _ascii-trees-section:
 
 Ascii Trees
 -----------
@@ -11,6 +15,8 @@ You can get a very simple ascii representation of the tree on stdout with :func:
 
 .. autofunction:: py_trees.display.print_ascii_tree
     :noindex:
+
+.. _ascii-trees-runtime-section:
 
 Ascii Trees (Runtime)
 ---------------------
@@ -21,6 +27,8 @@ with the :func:`~py_trees.display.ascii_tree` function:
 
 .. autofunction:: py_trees.display.ascii_tree
     :noindex:
+
+.. _render-to-file-section:
 
 Render to File (Dot/SVG/PNG)
 ----------------------------

--- a/py_trees/decorators.py
+++ b/py_trees/decorators.py
@@ -30,19 +30,19 @@ An example:
 
 Decorators with very specific functionality:
 
-* :func:`py_trees.decorators.Condition`
-* :func:`py_trees.decorators.Inverter`
-* :func:`py_trees.decorators.OneShot`
-* :func:`py_trees.decorators.TimeOut`
+* :class:`py_trees.decorators.Condition`
+* :class:`py_trees.decorators.Inverter`
+* :class:`py_trees.decorators.OneShot`
+* :class:`py_trees.decorators.Timeout`
 
 And the X is Y family:
 
-* :func:`py_trees.decorators.FailureIsRunning`
-* :func:`py_trees.decorators.FailureIsSuccess`
-* :func:`py_trees.decorators.RunningIsFailure`
-* :func:`py_trees.decorators.RunningIsSuccess`
-* :func:`py_trees.decorators.SuccessIsFailure`
-* :func:`py_trees.decorators.SuccessIsRunning`
+* :class:`py_trees.decorators.FailureIsRunning`
+* :class:`py_trees.decorators.FailureIsSuccess`
+* :class:`py_trees.decorators.RunningIsFailure`
+* :class:`py_trees.decorators.RunningIsSuccess`
+* :class:`py_trees.decorators.SuccessIsFailure`
+* :class:`py_trees.decorators.SuccessIsRunning`
 
 **Decorators for Blocking Behaviours**
 


### PR DESCRIPTION
This helps link to different sections in the document when using
intersphinx.
This PR also fixes some minor errors related to intersphinx mapping as
well as fixing the links for certain decorators.