### PR TITLE
[display] unicode overhaul and ascii art api refactor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Release Notes
 =============
 
+1.1.x (2019-xx-yy)
+------------------
+
+**Breaking API**
+
+* [display] print_ascii_tree -> ascii_tree, `#178 <https://github.com/splintered-reality/py_trees/issues/178>`_.
+* [display] generate_pydot_graph -> dot_graph, `#178 <https://github.com/splintered-reality/py_trees/issues/178>`_.
+
+**New Features**
+
+* ...
+
+1.0.7 (2019-xx-yy)
+------------------
+* [display] optional arguments for generate_pydot_graph
+
 1.0.6 (2019-03-06)
 ------------------
 * [decorators] fix missing root feedback message in ascii graphs

--- a/py_trees/common.py
+++ b/py_trees/common.py
@@ -75,7 +75,7 @@ class ParallelPolicy(object):
             """
             description = "--" + self.__class__.__name__ + "("
             description += console.lightning_bolt if self.synchronise else "-"
-            description += "--"
+            description += ")--"
             return description
 
     class SuccessOnOne(Base):

--- a/py_trees/console.py
+++ b/py_trees/console.py
@@ -60,7 +60,7 @@ def has_unicode(encoding: str=sys.stdout.encoding) -> bool:
     return True
 
 
-def define_symbol_or_fallback(original: str, fallback: str, encoding: str = sys.stdout.encoding):
+def define_symbol_or_fallback(original: str, fallback: str, encoding: str=sys.stdout.encoding):
     """
     Return the correct encoding according to the specified encoding. Used to
     make sure we get an appropriate symbol, even if the shell is merely ascii as
@@ -324,3 +324,4 @@ if __name__ == '__main__':
     print("double_vertical_line: {}".format(double_vertical_line))
     print("check_mark: {}".format(check_mark))
     print("multiplication_x: {}".format(multiplication_x))
+    # print("has unicode: {}".format(has_unicode()))

--- a/py_trees/console.py
+++ b/py_trees/console.py
@@ -41,6 +41,19 @@ import sys
 ##############################################################################
 
 def correct_encode(original: str, replacement: str, encoding: str = sys.stdout.encoding):
+    """
+    Return the correct encoding according to the specified encoding. Used to
+    make sure we get an appropriate symbol, even if the shell is merely ascii as
+    is often the case on, e.g. Jenkins CI.
+
+    Args:
+        original (:obj:`str`): the unicode string (usually just a character)
+        replacement (:obj:`str`): the fallback ascii string
+        encoding (:obj:`str`, optional): the encoding to check against.
+
+    Returns:
+        :obj:`str`: either the original or replacement depending on whether exceptions were thrown.
+    """
     try:
         original.encode(encoding)
     except UnicodeError:
@@ -53,6 +66,26 @@ double_vertical_line = correct_encode(u'\u2016', "||")
 check_mark = correct_encode(u'\u2713', "S")
 multiplication_x = correct_encode(u'\u2715', "F")
 
+
+def forceably_replace_unicode_chars(original: str):
+    """
+    Workaround for, e.g. ROS messages until they support unicode.
+
+    Args:
+        original (:obj:`str`): the unicode string (usually just a character)
+
+    Returns:
+        :obj:`str`: the original string with unicode replacements
+    """
+    unicode_ascii_symbols = {
+        u'\u26A1': "SYNC",
+        u'\u2016': "||",
+        u'\u2713': "S",
+        u'\u2715': "F"
+    }
+    for unicode, replacement in unicode_ascii_symbols.items():
+        original = original.replace(unicode, replacement)
+    return original
 
 ##############################################################################
 # Keypress

--- a/py_trees/console.py
+++ b/py_trees/console.py
@@ -40,7 +40,27 @@ import sys
 # Special Characters
 ##############################################################################
 
-def correct_encode(original: str, replacement: str, encoding: str = sys.stdout.encoding):
+
+def has_unicode(encoding: str=sys.stdout.encoding) -> bool:
+    """
+    Define whether the specified encoding has unicode symbols. Usually used to check
+    if the stdout is capable or otherwise (e.g. Jenkins CI can often be configured
+    with unicode disabled).
+
+    Args:
+        encoding (:obj:`str`, optional): the encoding to check against.
+
+    Returns:
+        :obj:`bool`: true if capable, false otherwise
+    """
+    try:
+        u'\u26A1'.encode(encoding)
+    except UnicodeError:
+        return False
+    return True
+
+
+def define_symbol_or_fallback(original: str, fallback: str, encoding: str = sys.stdout.encoding):
     """
     Return the correct encoding according to the specified encoding. Used to
     make sure we get an appropriate symbol, even if the shell is merely ascii as
@@ -48,44 +68,23 @@ def correct_encode(original: str, replacement: str, encoding: str = sys.stdout.e
 
     Args:
         original (:obj:`str`): the unicode string (usually just a character)
-        replacement (:obj:`str`): the fallback ascii string
+        fallback (:obj:`str`): the fallback ascii string
         encoding (:obj:`str`, optional): the encoding to check against.
 
     Returns:
-        :obj:`str`: either the original or replacement depending on whether exceptions were thrown.
+        :obj:`str`: either original or fallback depending on whether exceptions were thrown.
     """
     try:
         original.encode(encoding)
     except UnicodeError:
-        return replacement
+        return fallback
     return original
 
 
-lightning_bolt = correct_encode(u'\u26A1', "SYNC")
-double_vertical_line = correct_encode(u'\u2016', "||")
-check_mark = correct_encode(u'\u2713', "S")
-multiplication_x = correct_encode(u'\u2715', "F")
-
-
-def forceably_replace_unicode_chars(original: str):
-    """
-    Workaround for, e.g. ROS messages until they support unicode.
-
-    Args:
-        original (:obj:`str`): the unicode string (usually just a character)
-
-    Returns:
-        :obj:`str`: the original string with unicode replacements
-    """
-    unicode_ascii_symbols = {
-        u'\u26A1': "SYNC",
-        u'\u2016': "||",
-        u'\u2713': "S",
-        u'\u2715': "F"
-    }
-    for unicode, replacement in unicode_ascii_symbols.items():
-        original = original.replace(unicode, replacement)
-    return original
+lightning_bolt = u'\u26A1'
+double_vertical_line = u'\u2016'
+check_mark = u'\u2713'
+multiplication_x = u'\u2715'
 
 ##############################################################################
 # Keypress
@@ -118,8 +117,8 @@ def read_single_keypress():
         attrs = list(attrs_save)  # copy the stored version to update
         # iflag
         attrs[0] &= ~(termios.IGNBRK | termios.BRKINT | termios.PARMRK |
-                    termios.ISTRIP | termios.INLCR | termios. IGNCR |
-                    termios.ICRNL | termios.IXON)
+                      termios.ISTRIP | termios.INLCR | termios. IGNCR |
+                      termios.ICRNL | termios.IXON)
         # oflag
         attrs[1] &= ~termios.OPOST
         # cflag
@@ -127,7 +126,7 @@ def read_single_keypress():
         attrs[2] |= termios.CS8
         # lflag
         attrs[3] &= ~(termios.ECHONL | termios.ECHO | termios.ICANON |
-                    termios.ISIG | termios.IEXTEN)
+                      termios.ISIG | termios.IEXTEN)
         termios.tcsetattr(fd, termios.TCSANOW, attrs)
         # turn off non-blocking
         fcntl.fcntl(fd, fcntl.F_SETFL, flags_save & ~os.O_NONBLOCK)
@@ -146,7 +145,7 @@ def read_single_keypress():
         """Windows case, can't use fcntl and termios.
         Not same implementation as for Unix, requires a newline to continue.
         """
-        import msvcrt
+        import msvcrt  # noqa
         # read a single keystroke
         ret = sys.stdin.read(1)
         if ord(ret) == 3:  # CTRL-C
@@ -158,7 +157,7 @@ def read_single_keypress():
         try:
             return read_single_keypress_windows()
         except ImportError as e_windows:
-            raise ImportError("Neither unix nor windows implementations supported [{}][{}]".format(str(e_unix),str(e_windows)))
+            raise ImportError("Neither unix nor windows implementations supported [{}][{}]".format(str(e_unix), str(e_windows)))
 
 ##############################################################################
 # Methods

--- a/py_trees/demos/blackboard.py
+++ b/py_trees/demos/blackboard.py
@@ -117,7 +117,7 @@ def main():
     # Rendering
     ####################
     if args.render:
-        py_trees.display.render_dot_tree(tree)
+        py_trees.display.render_dot_tree(root)
         sys.exit()
 
     ####################
@@ -127,6 +127,6 @@ def main():
     print("\n--------- Tick 0 ---------\n")
     root.tick_once()
     print("\n")
-    py_trees.display.print_ascii_tree(root, show_status=True)
+    print(py_trees.display.ascii_tree(root, show_status=True))
     print("\n")
     print(py_trees.blackboard.Blackboard())

--- a/py_trees/demos/context_switching.py
+++ b/py_trees/demos/context_switching.py
@@ -164,7 +164,7 @@ def main():
             print("\n--------- Tick {0} ---------\n".format(i))
             root.tick_once()
             print("\n")
-            py_trees.display.print_ascii_tree(root, show_status=True)
+            print("{}".format(py_trees.display.ascii_tree(root, show_status=True)))
             time.sleep(1.0)
         except KeyboardInterrupt:
             break

--- a/py_trees/demos/logging.py
+++ b/py_trees/demos/logging.py
@@ -128,7 +128,8 @@ def display_ascii_tree(snapshot_visitor, behaviour_tree):
     """
     print("\n" + py_trees.display.ascii_tree(
         behaviour_tree.root,
-        snapshot_information=snapshot_visitor)
+        visited=snapshot_visitor.visited,
+        previously_visited=snapshot_visitor.previously_visited)
     )
 
 

--- a/py_trees/demos/pick_up_where_you_left_off.py
+++ b/py_trees/demos/pick_up_where_you_left_off.py
@@ -95,8 +95,13 @@ def post_tick_handler(snapshot_visitor, behaviour_tree):
     """
     Prints an ascii tree with the current snapshot status.
     """
-    print("\n" + py_trees.display.ascii_tree(behaviour_tree.root,
-                                             snapshot_information=snapshot_visitor))
+    print(
+        "\n" + py_trees.display.ascii_tree(
+            root=behaviour_tree.root,
+            visited=snapshot_visitor.visited,
+            previously_visited=snapshot_visitor.previously_visited
+        )
+    )
 
 
 def create_root():

--- a/py_trees/demos/selector.py
+++ b/py_trees/demos/selector.py
@@ -112,7 +112,7 @@ def main():
             print("\n--------- Tick {0} ---------\n".format(i))
             root.tick_once()
             print("\n")
-            py_trees.display.print_ascii_tree(root, show_status=True)
+            print(py_trees.display.ascii_tree(root=root, show_status=True))
             time.sleep(1.0)
         except KeyboardInterrupt:
             break

--- a/py_trees/demos/sequence.py
+++ b/py_trees/demos/sequence.py
@@ -111,7 +111,7 @@ def main():
             print("\n--------- Tick {0} ---------\n".format(i))
             root.tick_once()
             print("\n")
-            py_trees.display.print_ascii_tree(root, show_status=True)
+            print(py_trees.display.ascii_tree(root=root, show_status=True))
             time.sleep(1.0)
         except KeyboardInterrupt:
             break

--- a/py_trees/demos/stewardship.py
+++ b/py_trees/demos/stewardship.py
@@ -96,8 +96,11 @@ def post_tick_handler(snapshot_visitor, behaviour_tree):
     """
     Prints an ascii tree with the current snapshot status.
     """
-    print("\n" + py_trees.display.ascii_tree(behaviour_tree.root,
-                                             snapshot_information=snapshot_visitor))
+    print("\n" + py_trees.display.ascii_tree(
+        root=behaviour_tree.root,
+        visited=snapshot_visitor.visited,
+        previously_visited=snapshot_visitor.visited)
+    )
 
 
 def create_tree():

--- a/py_trees/display.py
+++ b/py_trees/display.py
@@ -123,7 +123,7 @@ def ascii_tree(
                                   snapshot_visitor))
             behaviour_tree.visitors.append(snapshot_visitor)
     """
-    symbols = unicode_symbols if console.has_unicode('utf-8') else ascii_symbols
+    symbols = unicode_symbols if console.has_unicode() else ascii_symbols
 
     def get_behaviour_type(b):
         for behaviour_type in [composites.Sequence,

--- a/py_trees/display.py
+++ b/py_trees/display.py
@@ -12,6 +12,14 @@ Behaviour trees are significantly easier to design, monitor and debug
 with visualisations. Py Trees does provide minimal assistance to render
 trees to various simple output formats. Currently this includes dot graphs,
 strings or stdout.
+
+.. warning::
+
+   There is both disrespect for ascii and lack of recognition for unicode
+   in this file as the intention to make ascii art a first class citizen
+   in py_trees became tainted by the desire to make use of the very fine
+   looking unicode symbols underneath. If such behaviour offends, please
+   wear your peril-sensitive sunglasses when parsing or using this module.
 """
 
 ##############################################################################
@@ -32,105 +40,47 @@ from . import utilities
 # Methods
 ##############################################################################
 
+unicode_symbols = {
+    composites.Sequence: u'[-]',
+    composites.Selector: u'[o]',
+    composites.Parallel: u'[' + console.double_vertical_line + u']',
+    decorators.Decorator: u'-^-',
+    behaviour.Behaviour: u'-->',
+    common.Status.SUCCESS: console.green + console.check_mark + console.reset,
+    common.Status.FAILURE: console.red + console.multiplication_x + console.reset,
+    common.Status.INVALID: console.yellow + u'-' + console.reset,
+    common.Status.RUNNING: console.blue + u'*' + console.reset
+}
 
-@utilities.static_variables(
-    type_to_unicode={
-        composites.Sequence: "[-] ",
-        composites.Selector: "[o] ",
-        composites.Parallel: "[" + console.double_vertical_line + "] ",
-        decorators.Decorator: "-^- ",
-        behaviour.Behaviour: "--> "
-    }
-)
-def ascii_bullet(node):
+ascii_symbols = {
+    composites.Sequence: "[-]",
+    composites.Selector: "[o]",
+    composites.Parallel: "[||]",
+    decorators.Decorator: "-^-",
+    behaviour.Behaviour: "-->",
+    common.Status.SUCCESS: console.green + 'o' + console.reset,
+    common.Status.FAILURE: console.red + 'x' + console.reset,
+    common.Status.INVALID: console.yellow + '-' + console.reset,
+    common.Status.RUNNING: console.blue + '*' + console.reset
+}
+
+
+def ascii_tree(
+        root,
+        show_status=False,
+        visited={},
+        previously_visited={},
+        indent=0,
+     ):
     """
-    Generate a text bullet for the specified behaviour's type.
+    Graffiti your console with with ascii trees.
 
     Args:
-        node (:class:`~py_trees.behaviour.Behaviour`): convert this behaviour's type to text
-
-    Returns:
-        :obj:`str`): the text bullet
-    """
-    for behaviour_type in [composites.Sequence,
-                           composites.Selector,
-                           composites.Parallel,
-                           decorators.Decorator]:
-        if isinstance(node, behaviour_type):
-            return ascii_bullet.type_to_unicode[behaviour_type]
-    return ascii_bullet.type_to_unicode[behaviour.Behaviour]
-
-
-@utilities.static_variables(
-    status_to_unicode={
-        common.Status.SUCCESS: console.green + console.check_mark + console.reset,
-        common.Status.FAILURE: console.red + console.multiplication_x + console.reset,
-        common.Status.INVALID: console.yellow + u'-' + console.reset,
-        common.Status.RUNNING: console.blue + u'*' + console.reset
-    }
-)
-def ascii_check_mark(status):
-    """
-    Generate a text check mark for the specified status.
-
-    Args:
-        status (:class:`~py_trees.common.Status`): convert this status to text
-
-    Returns:
-        :obj:`str`): the text check mark
-    """
-    return ascii_check_mark.status_to_unicode[status]
-
-
-def _generate_ascii_tree(tree, indent=0, snapshot_information=None):
-    """
-    Generator for spinning out the ascii tree.
-
-    Args:
-        tree (:class:`~py_trees.behaviour.Behaviour`): the root of the tree, or subtree you want to show
+        root (:class:`~py_trees.behaviour.Behaviour`): the root of the tree, or subtree you want to show
         indent (:obj:`int`): the number of characters to indent the tree
-        snapshot_information (:mod:`~py_trees.visitors`): a visitor that recorded information about a traversed tree (e.g. :class:`~py_trees.visitors.SnapshotVisitor`)
-
-    Yields:
-        :obj:`str`: a string with information about a single behaviour in the tree
-    """
-
-    nodes = {} if snapshot_information is None else snapshot_information.nodes
-    previously_running_nodes = [] if snapshot_information is None else snapshot_information.previously_running_nodes
-    running_nodes = [] if snapshot_information is None else snapshot_information.running_nodes
-    if indent == 0:
-        if tree.id in nodes:
-            message = "" if not tree.feedback_message else " -- " + tree.feedback_message
-            yield "%s [%s]" % (tree.name.replace('\n', ' '), ascii_check_mark(nodes[tree.id])) + message
-        elif tree.id in previously_running_nodes and tree.id not in running_nodes:
-            yield "%s" % tree.name.replace('\n', ' ') + " [" + console.yellow + "-" + console.reset + "]"
-        else:
-            yield "%s" % tree.name.replace('\n', ' ')
-    for child in tree.children:
-        bullet = ascii_bullet(child)
-        if child.id in nodes:
-            message = "" if not child.feedback_message else " -- " + child.feedback_message
-            yield "    " * indent + bullet + child.name.replace('\n', ' ') + " [%s]" % ascii_check_mark(nodes[child.id]) + message
-        elif child.id in previously_running_nodes and child.id not in running_nodes:
-            yield "    " * indent + bullet + child.name.replace('\n', ' ') + " [" + console.yellow + "-" + console.reset + "]"
-        else:
-            yield "    " * indent + bullet + child.name.replace('\n', ' ')
-        if child.children != []:
-            for line in _generate_ascii_tree(child, indent + 1, snapshot_information):
-                yield line
-
-
-def ascii_tree(tree, indent=0, snapshot_information=None):
-    """
-    Build an ascii tree representation as a string for redirecting
-    to elsewhere other than stdout. This can be the entire tree, or
-    a recorded snapshot of the tree (i.e. just the part that was traversed).
-
-    Args:
-        tree (:class:`~py_trees.behaviour.Behaviour`): the root of the tree, or subtree you want to show
-        indent (:obj:`int`): the number of characters to indent the tree
-        snapshot_information (:mod:`~py_trees.visitors`): a visitor that recorded information about a traversed tree (e.g. :class:`~py_trees.visitors.SnapshotVisitor`)
-        snapshot_information (:mod:`~py_trees.visitors`): a visitor that recorded information about a traversed tree (e.g. :class:`~py_trees.visitors.SnapshotVisitor`)
+        show_status (:obj:`bool`): always show status and feedback message (i.e. for every element, not just those visited)
+        visited (dict): dictionary of (uuid.UUID) and status (:class:`~py_trees.common.Status`) pairs for behaviours visited on the current tick
+        previously_visited (dict): dictionary of behaviour id/status pairs from the previous tree tick
 
     Returns:
         :obj:`str`: an ascii tree (i.e. in string form)
@@ -150,8 +100,13 @@ def ascii_tree(tree, indent=0, snapshot_information=None):
         .. code-block:: python
 
             def post_tick_handler(snapshot_visitor, behaviour_tree):
-                print(py_trees.display.ascii_tree(behaviour_tree.root,
-                      snapshot_information=snapshot_visitor))
+                print(
+                    py_trees.display.ascii_tree(
+                        behaviour_tree.root,
+                        visited=snapshot_visitor.visited,
+                        previously_visited=snapshot_visitor.visited
+                    )
+                )
 
             root = py_trees.composites.Sequence("Sequence")
             for action in ["Action 1", "Action 2", "Action 3"]:
@@ -167,63 +122,51 @@ def ascii_tree(tree, indent=0, snapshot_information=None):
                 functools.partial(post_tick_handler,
                                   snapshot_visitor))
             behaviour_tree.visitors.append(snapshot_visitor)
-
     """
+    symbols = unicode_symbols if console.has_unicode('utf-8') else ascii_symbols
+
+    def get_behaviour_type(b):
+        for behaviour_type in [composites.Sequence,
+                               composites.Selector,
+                               composites.Parallel,
+                               decorators.Decorator]:
+            if isinstance(b, behaviour_type):
+                return behaviour_type
+        return behaviour.Behaviour
+
+    def generate_lines(root, indent):
+        if indent == 0:
+            if show_status or root.id in visited.keys():
+                message = "" if not root.feedback_message else " -- " + root.feedback_message
+                yield "%s [%s]" % (root.name.replace('\n', ' '),
+                                   symbols[root.status]) + message
+            elif (root.id in previously_visited.keys() and
+                  root.id not in visited.keys() and
+                  previously_visited[root.id] == common.Status.RUNNING):
+                yield "%s" % root.name.replace('\n', ' ') + " [" + console.yellow + "-" + console.reset + "]"
+            else:
+                yield "%s" % root.name.replace('\n', ' ')
+        for child in root.children:
+            prefix = symbols[get_behaviour_type(child)] + " "
+            if show_status or child.id in visited.keys():
+                message = "" if not child.feedback_message else " -- " + child.feedback_message
+                yield "    " * indent + prefix + child.name.replace('\n', ' ') + " [%s]" % symbols[child.status] + message
+            elif (child.id in previously_visited.keys() and
+                  child.id not in visited.keys() and
+                  previously_visited[root.id] == common.Status.RUNNING):
+                yield "    " * indent + prefix + child.name.replace('\n', ' ') + " [" + console.yellow + "-" + console.reset + "]"
+            else:
+                yield "    " * indent + prefix + child.name.replace('\n', ' ')
+            if child.children != []:
+                for line in generate_lines(child, indent + 1):
+                    yield line
     s = ""
-    for line in _generate_ascii_tree(tree, indent, snapshot_information):
+    for line in generate_lines(root, indent):
         s += "%s\n" % line
     return s
 
 
-def print_ascii_tree(root, indent=0, show_status=False):
-    """
-    Print the ASCII representation of an entire behaviour tree.
-
-    Args:
-        root (:class:`~py_trees.behaviour.Behaviour`): the root of the tree, or subtree you want to show
-        indent (:obj:`int`): the number of characters to indent the tree
-        show_status (:obj:`bool`): additionally show feedback message and status of every element
-
-    Examples:
-
-        Render a simple tree in ascii format to stdout.
-
-        .. image:: images/ascii_tree_simple.png
-            :width: 100px
-            :align: right
-
-        .. code-block:: python
-
-            root = py_trees.composites.Sequence("Sequence")
-            for action in ["Action 1", "Action 2", "Action 3"]:
-                b = py_trees.behaviours.Count(
-                        name=action,
-                        fail_until=0,
-                        running_until=1,
-                        success_until=10)
-                root.add_child(b)
-            py_trees.display.print_ascii_tree(root)
-
-    .. tip::
-
-        To additionally display status and feedbback message from every behaviour in the tree,
-        simply set the :obj:`show_status` flag to True.
-    """
-    class InstantSnapshot(object):
-        def __init__(self, tree):
-            self.nodes = {}
-            self.previously_running_nodes = []
-            self.running_nodes = []
-            for node in tree.iterate():
-                self.nodes[node.id] = node.status
-                self.running_nodes.append(node.id)
-            self.previously_running_nodes = self.running_nodes
-    snapshot_information = InstantSnapshot(root) if show_status else None
-    for line in _generate_ascii_tree(root, indent, snapshot_information):
-        print("%s" % line)
-
-
-def generate_pydot_graph(
+def dot_graph(
         root: behaviour.Behaviour,
         visibility_level: common.VisibilityLevel=common.VisibilityLevel.DETAIL,
         collapse_decorators: bool=False,
@@ -240,6 +183,13 @@ def generate_pydot_graph(
 
     Returns:
         pydot.Dot: graph
+
+    Examples:
+
+        .. code-block:: python
+
+            # convert the pydot graph to a string object
+            print("{}".format(py_trees.display.dot_graph(root).to_string()))
     """
     def get_node_attributes(node):
         blackbox_font_colours = {common.BlackBoxLevel.DETAIL: "dodgerblue",
@@ -325,21 +275,6 @@ def generate_pydot_graph(
     return graph
 
 
-def stringify_dot_tree(root):
-    """
-    Generate dot tree graphs and return a string representation
-    of the dot graph.
-
-    Args:
-        root (:class:`~py_trees.behaviour.Behaviour`): the root of a tree, or subtree
-
-    Returns:
-        :obj:`str`: dot graph as a string
-    """
-    graph = generate_pydot_graph(root, visibility_level=common.VisibilityLevel.DETAIL)
-    return graph.to_string()
-
-
 def render_dot_tree(root: behaviour.Behaviour,
                     visibility_level: common.VisibilityLevel=common.VisibilityLevel.DETAIL,
                     collapse_decorators: bool=False,
@@ -380,7 +315,7 @@ def render_dot_tree(root: behaviour.Behaviour,
         A good practice is to provide a command line argument for optional rendering of a program so users
         can quickly visualise what tree the program will execute.
     """
-    graph = generate_pydot_graph(root, visibility_level, collapse_decorators, with_qualified_names=with_qualified_names)
+    graph = dot_graph(root, visibility_level, collapse_decorators, with_qualified_names=with_qualified_names)
     filename_wo_extension_to_convert = root.name if name is None else name
     filename_wo_extension = utilities.get_valid_filename(filename_wo_extension_to_convert)
     filenames = {}

--- a/py_trees/tests.py
+++ b/py_trees/tests.py
@@ -31,7 +31,7 @@ def pre_tick_visitor(behaviour_tree):
     print("\n--------- Run %s ---------\n" % behaviour_tree.count)
 
 
-def tick_tree(tree,
+def tick_tree(root,
               from_tick,
               to_tick,
               *,
@@ -44,12 +44,12 @@ def tick_tree(tree,
         for visitor in visitors:
             visitor.initialise()
         print(("\n--------- Run %s ---------\n" % i))
-        for node in tree.tick():
+        for node in root.tick():
             for visitor in visitors:
                 node.visit(visitor)
     if print_snapshot:
         print(console.green + "\nAscii Tree Snapshot" + console.reset)
-        display.print_ascii_tree(tree, show_status=True)
+        print(display.ascii_tree(root=root, show_status=True))
     if print_blackboard:
         print(str(blackboard.Blackboard()))
 

--- a/py_trees/utilities.py
+++ b/py_trees/utilities.py
@@ -19,6 +19,29 @@ import os
 import re
 
 ##############################################################################
+# Python Helpers
+##############################################################################
+
+
+def static_variables(**kwargs):
+    """
+    This is a decorator that can be used with python methods to attach
+    initialised static variables to the method.
+
+    .. code-block:: python
+
+       @static_variables(counter=0)
+       def foo():
+           foo.counter += 1
+           print("Counter: {}".format(foo.counter))
+    """
+    def decorate(func):
+        for k in kwargs:
+            setattr(func, k, kwargs[k])
+        return func
+    return decorate
+
+##############################################################################
 # System Tools
 ##############################################################################
 
@@ -93,26 +116,3 @@ def get_fully_qualified_name(instance: object) -> str:
         return instance.__class__.__name__
     else:
         return module + '.' + instance.__class__.__name__
-
-##############################################################################
-# Python Helpers
-##############################################################################
-
-
-def static_variables(**kwargs):
-    """
-    This is a decorator that can be used with python methods to attach
-    initialised static variables to the method.
-
-    .. code-block:: python
-
-       @static_variables(counter=0)
-       def foo():
-           foo.counter += 1
-           print("Counter: {}".format(foo.counter))
-    """
-    def decorate(func):
-        for k in kwargs:
-            setattr(func, k, kwargs[k])
-        return func
-    return decorate

--- a/py_trees/visitors.py
+++ b/py_trees/visitors.py
@@ -82,49 +82,42 @@ class DebugVisitor(VisitorBase):
 
 class SnapshotVisitor(VisitorBase):
     """
-    Visits the tree in tick-tock, recording runtime information for publishing
-    the information as a snapshot view of the tree after the iteration has
-    finished.
+    Visits the tree in tick-tock, recording the id/status of the visited set
+    of nodes. Additionally caches the last tick's visited collection for
+    comparison.
 
     Args:
         full (:obj:`bool`): flag to indicate whether it should be used to visit only traversed nodes or the entire tree
 
     Attributes:
-        nodes (dict): dictionary of behaviour id (uuid.UUID) and status (:class:`~py_trees.common.Status`) pairs
-        running_nodes([uuid.UUID]): list of id's for behaviours which were traversed in the current tick
-        previously_running_nodes([uuid.UUID]): list of id's for behaviours which were traversed in the last tick
+        visited (dict): dictionary of behaviour id (uuid.UUID) and status (:class:`~py_trees.common.Status`) pairs
+        previously_visited (dict): dictionary of behaviour id's saved from the previous tree tick
 
     .. seealso::
 
         This visitor is used with the :class:`~py_trees.trees.BehaviourTree` class to collect
-        information and :func:`~py_trees.display.ascii_tree` to display information.
+        information and :func:`~py_trees.display.generate_ascii_tree` to display information.
     """
     def __init__(self, full=False):
         super(SnapshotVisitor, self).__init__(full=full)
-        self.nodes = {}
-        self.running_nodes = []
-        self.previously_running_nodes = []
+        self.visited = {}
+        self.previously_visited = {}
 
     def initialise(self):
         """
-        Switch running to previously running and then reset all other variables. This should
-        get called before a tree ticks.
+        Cache the last collection of visited nodes and reset the dictionary.
         """
-        self.nodes = {}
-        self.previously_running_nodes = self.running_nodes
-        self.running_nodes = []
+        self.previously_visited = self.visited
+        self.visited = {}
 
     def run(self, behaviour):
         """
         This method gets run as each behaviour is ticked. Catch the id and status and store it.
-        Additionally add it to the running list if it is :data:`~py_trees.common.Status.RUNNING`.
 
         Args:
             behaviour (:class:`~py_trees.behaviour.Behaviour`): behaviour that is ticking
         """
-        self.nodes[behaviour.id] = behaviour.status
-        if behaviour.status == common.Status.RUNNING:
-            self.running_nodes.append(behaviour.id)
+        self.visited[behaviour.id] = behaviour.status
 
 
 class WindsOfChangeVisitor(VisitorBase):

--- a/tests/test_chooser.py
+++ b/tests/test_chooser.py
@@ -30,7 +30,7 @@ def test_low_priority_runner():
     running = py_trees.behaviours.Running("Running")
     root.add_child(failure)
     root.add_child(running)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor])
 
@@ -60,7 +60,7 @@ def test_low_priority_success():
     success = py_trees.behaviours.Success("Success")
     root.add_child(failure)
     root.add_child(success)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor])
 
@@ -91,7 +91,7 @@ def test_higher_priority_ignore():
     running = py_trees.behaviours.Running("Running")
     root.add_child(ping_pong)
     root.add_child(running)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor])
 

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -26,6 +26,7 @@ logger = py_trees.logging.Logger("Nosetest")
 # Tests
 ##############################################################################
 
+
 def test_replacing_children():
     console.banner("Replacing Children")
     parent = py_trees.composites.Sequence(name="Parent")
@@ -57,6 +58,7 @@ def test_removing_children():
     parent.add_child(child)
     parent.remove_all_children()
     assert(child.parent is None)
+
 
 def test_composite_errors():
     console.banner("Timer Errors")

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -17,5 +17,5 @@ import py_trees
 
 
 def test_correct_encode():
-    assert py_trees.console.correct_encode(u'\u26A1', "a", "ascii") == "a"
-    assert py_trees.console.correct_encode(u'\u26A1', "a", "utf-8") == u'\u26A1'
+    assert py_trees.console.define_symbol_or_fallback(u'\u26A1', "a", "ascii") == "a"
+    assert py_trees.console.define_symbol_or_fallback(u'\u26A1', "a", "utf-8") == u'\u26A1'

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -52,7 +52,7 @@ def test_failure_is_success_tree():
     )
     root.add_child(failure)
     root.add_child(failure_is_success)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor], print_snapshot=True)
 
@@ -186,7 +186,7 @@ def test_success_is_failure_tree():
     )
     root.add_child(failure)
     root.add_child(success_is_failure)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor], print_snapshot=True)
 
@@ -214,7 +214,7 @@ def test_inverter():
     selector.add_child(success)
     root.add_child(selector)
     root.add_child(failure_inverter)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
 
     for i in range(0, 2):
@@ -277,7 +277,7 @@ def test_timeout():
     console.banner("Timeout")
     running = py_trees.behaviours.Running(name="Running")
     timeout = py_trees.decorators.Timeout(child=running, duration=0.2)
-    py_trees.display.print_ascii_tree(timeout)
+    print(py_trees.display.ascii_tree(timeout))
     visitor = py_trees.visitors.DebugVisitor()
 
     # Test that it times out and re-initialises properly
@@ -308,7 +308,7 @@ def test_timeout():
         reset=False
     )
     timeout = py_trees.decorators.Timeout(child=count, duration=0.2)
-    py_trees.display.print_ascii_tree(timeout)
+    print(py_trees.display.ascii_tree(timeout))
 
     py_trees.tests.tick_tree(timeout, 1, 1, visitors=[visitor])
 
@@ -329,7 +329,7 @@ def test_timeout():
     # test that it passes on failure
     failure = py_trees.behaviours.Failure()
     timeout = py_trees.decorators.Timeout(child=failure, duration=0.2)
-    py_trees.display.print_ascii_tree(timeout)
+    print(py_trees.display.ascii_tree(timeout))
 
     py_trees.tests.tick_tree(timeout, 1, 1, visitors=[visitor])
 
@@ -348,7 +348,7 @@ def test_timeout():
         reset=False
     )
     timeout = py_trees.decorators.Timeout(child=count, duration=0.1)
-    py_trees.display.print_ascii_tree(timeout)
+    print(py_trees.display.ascii_tree(timeout))
 
     py_trees.tests.tick_tree(timeout, 1, 1, visitors=[visitor])
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -8,6 +8,7 @@
 # Imports
 ##############################################################################
 
+import functools
 import py_trees
 import py_trees.console as console
 import py_trees.display as display
@@ -34,9 +35,52 @@ def test_symbols():
     )
 
     print("[{0}][{1}][{2}][{3}]".format(
-        symbols[py_trees.behaviours.Success()],
-        symbols[py_trees.composites.Sequence()],
-        symbols[py_trees.composites.Selector()],
-        symbols[py_trees.composites.Parallel()]
+        symbols[py_trees.behaviours.Behaviour],
+        symbols[py_trees.composites.Sequence],
+        symbols[py_trees.composites.Selector],
+        symbols[py_trees.composites.Parallel]
         )
     )
+
+
+def test_ascii_snapshot_priority_interrupt():
+    """
+    Tickle the ascii tree generator, but also check specifically
+    that a running node that is priority interrupted still gets
+    shown as invalidated ('-') via the visitor mechanisms.
+    """
+    console.banner("Ascii Snapshots - Priority Interrupt")
+
+    def post_tick_handler(snapshot_visitor, tree):
+        print(
+            py_trees.display.ascii_tree(
+                tree.root,
+                visited=snapshot_visitor.visited,
+                previously_visited=snapshot_visitor.previously_visited
+            )
+        )
+
+    root = py_trees.composites.Selector("Selector")
+    root.add_child(
+        py_trees.behaviours.Count(
+            name="High Priority",
+            fail_until=1,
+            running_until=1,
+            success_until=10
+        )
+    )
+    root.add_child(py_trees.behaviours.Running(name="Low Priority"))
+    tree = py_trees.trees.BehaviourTree(root)
+    snapshot_visitor = py_trees.visitors.SnapshotVisitor()
+    tree.visitors.append(snapshot_visitor)
+    tree.add_post_tick_handler(functools.partial(post_tick_handler, snapshot_visitor))
+    tree.tick()
+    tree.tick()
+    last_line = py_trees.display.ascii_tree(
+        tree.root,
+        visited=snapshot_visitor.visited,
+        previously_visited=snapshot_visitor.previously_visited
+    ).splitlines()[-1]
+    print("\n--------- Assertions ---------\n")
+    print("Invalidated Lower Priority Symbol '-' is displayed")
+    assert('-' in last_line)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -21,14 +21,22 @@ def test_symbols():
     console.banner("Symbols")
     # This test has no assertions, except from the human eye. When it fails,
     # ticks and crosses fail and must be inspected by the human eye
+    if console.has_unicode():
+        symbols = display.unicode_symbols
+    else:
+        symbols = display.ascii_symbols
     print("[{0}][{1}][{2}][{3}]".format(
-        display.ascii_check_mark(py_trees.common.Status.SUCCESS),
-        display.ascii_check_mark(py_trees.common.Status.FAILURE),
-        display.ascii_check_mark(py_trees.common.Status.INVALID),
-        display.ascii_check_mark(py_trees.common.Status.RUNNING)))
+        symbols[py_trees.common.Status.SUCCESS],
+        symbols[py_trees.common.Status.FAILURE],
+        symbols[py_trees.common.Status.INVALID],
+        symbols[py_trees.common.Status.RUNNING]
+        )
+    )
 
     print("[{0}][{1}][{2}][{3}]".format(
-        display.ascii_bullet(py_trees.behaviours.Success()),
-        display.ascii_bullet(py_trees.composites.Sequence()),
-        display.ascii_bullet(py_trees.composites.Selector()),
-        display.ascii_bullet(py_trees.composites.Parallel())))
+        symbols[py_trees.behaviours.Success()],
+        symbols[py_trees.composites.Sequence()],
+        symbols[py_trees.composites.Selector()],
+        symbols[py_trees.composites.Parallel()]
+        )
+    )

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -22,8 +22,10 @@ logger = py_trees.logging.Logger("Nosetest")
 # Tests
 ##############################################################################
 
+
 def test_behaviour_from_function_naming():
     console.banner("Test Behaviour From Function Naming")
+
     def foo():
         return py_trees.common.Status.SUCCESS
     foo_instance = py_trees.meta.create_behaviour_from_function(foo)()

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -60,7 +60,7 @@ def test_oneshot_with_fail_causes_reentry():
 
             # Ticking
             py_trees.tests.tick_tree(
-                tree=oneshot,
+                root=oneshot,
                 from_tick=1,
                 to_tick=1,
                 print_snapshot=True,
@@ -80,7 +80,7 @@ def test_oneshot_with_fail_causes_reentry():
 
             # Ticking
             py_trees.tests.tick_tree(
-                tree=oneshot,
+                root=oneshot,
                 from_tick=2,
                 to_tick=2,
                 print_snapshot=True,
@@ -148,7 +148,7 @@ def test_oneshot_with_subtrees_and_interrupt():
 
             # Ticking
             py_trees.tests.tick_tree(
-                tree=root,
+                root=root,
                 from_tick=1,
                 to_tick=2,
                 print_snapshot=True,
@@ -166,7 +166,7 @@ def test_oneshot_with_subtrees_and_interrupt():
             assert(oneshot.status == py_trees.common.Status.INVALID)
             assert(worker_subtree.status == py_trees.common.Status.INVALID)
             py_trees.tests.tick_tree(
-                tree=root,
+                root=root,
                 from_tick=3,
                 to_tick=3,
                 print_snapshot=True,

--- a/tests/test_parallels.py
+++ b/tests/test_parallels.py
@@ -31,7 +31,7 @@ def test_parallel_failure():
     success = py_trees.behaviours.Success("Success")
     root.add_child(failure)
     root.add_child(success)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor])
 
@@ -51,7 +51,7 @@ def test_parallel_success():
     success2 = py_trees.behaviours.Success("Success2")
     root.add_child(success1)
     root.add_child(success2)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor])
 
@@ -80,7 +80,7 @@ def test_parallel_running():
     root.add_child(success_after_1)
     root.add_child(running)
     root.add_child(success_every_other)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor])
 
@@ -118,7 +118,7 @@ def test_parallel_success_on_one():
     root.add_child(running1)
     root.add_child(success)
     root.add_child(running2)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor], print_snapshot=True)
 
@@ -156,7 +156,7 @@ def test_parallel_success_on_selected():
         )
     root.add_children([running1, success1, success2, running2])
 
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
 
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor], print_snapshot=True)
@@ -235,7 +235,7 @@ def test_parallel_synchronisation():
     )
 
     root.add_children([success, success_every_second])
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     debug_visitor = py_trees.visitors.DebugVisitor()
     snapshot_visitor = py_trees.visitors.SnapshotVisitor()
     py_trees.tests.tick_tree(
@@ -266,8 +266,8 @@ def test_parallel_synchronisation():
     assert(success.status == py_trees.common.Status.SUCCESS)
     print("success_every_second.status == py_trees.common.Status.SUCCESS")
     assert(success_every_second.status == py_trees.common.Status.SUCCESS)
-    print("success [id: {}] did not get ticked [snapshot: {}]".format(success.id, [str(ident) for ident in snapshot_visitor.nodes.keys()]))
-    assert(success.id not in snapshot_visitor.nodes)
+    print("success [id: {}] did not get ticked [snapshot: {}]".format(success.id, [str(ident) for ident in snapshot_visitor.visited.keys()]))
+    assert(success.id not in snapshot_visitor.visited)
 
     snapshot_visitor.initialise()
     py_trees.tests.tick_tree(

--- a/tests/test_pickup.py
+++ b/tests/test_pickup.py
@@ -47,7 +47,7 @@ def test_high_priority_interrupt():
     root = py_trees.composites.Selector(name="Root")
     root.add_children([high_priority_interrupt, piwylo])
 
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 3, visitors=[visitor])
     print()

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -23,10 +23,11 @@ logger = py_trees.logging.Logger("Nosetest")
 # Tests
 ##############################################################################
 
+
 def test_timer_errors():
     console.banner("Timer Errors")
     print("__init__ raises a 'TypeError' due to invalid duration being passed")
     with nose.tools.assert_raises(TypeError) as context:
-        timer = py_trees.timers.Timer(name="Timer", duration="invalid_type")
+        unused_timer = py_trees.timers.Timer(name="Timer", duration="invalid_type")
         print("TypeError has message with substring 'duration'")
         assert("duration" in str(context.exception))

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -78,7 +78,7 @@ def test_selector_composite():
     tree.add_child(a)
     tree.add_child(b)
     tree.add_child(c)
-    py_trees.display.print_ascii_tree(tree, 0)
+    print(py_trees.display.ascii_tree(tree))
     py_trees.tests.tick_tree(tree, 1, 3, visitors=[visitor])
     py_trees.tests.print_summary(nodes=[a, b, c])
     print("--------- Assertions ---------\n")
@@ -169,7 +169,7 @@ def test_mixed_tree():
     root.add_child(sequence)
     root.add_child(d)
 
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
 
     py_trees.tests.tick_tree(root, 1, 2, visitors=[visitor])
     py_trees.tests.print_summary(nodes=[a, b, c, d])
@@ -237,7 +237,7 @@ def test_display():
     root.add_child(sequence)
     root.add_child(d)
 
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
 
     assert(True)
 
@@ -281,13 +281,13 @@ def test_prune_behaviour_tree():
     root.add_child(d)
 
     tree = py_trees.trees.BehaviourTree(root)
-    py_trees.display.print_ascii_tree(tree.root)
+    print(py_trees.display.ascii_tree(tree.root))
     assert(len(sequence.children) == 2)
     tree.prune_subtree(c.id)
-    py_trees.display.print_ascii_tree(tree.root)
+    print(py_trees.display.ascii_tree(tree.root))
     assert(len(sequence.children) == 1)
     tree.prune_subtree(sequence.id)
-    py_trees.display.print_ascii_tree(tree.root)
+    print(py_trees.display.ascii_tree(tree.root))
     assert(len(root.children) == 2)
 
 
@@ -307,7 +307,7 @@ def test_replace_behaviour_tree():
     root.add_child(d)
 
     tree = py_trees.trees.BehaviourTree(root)
-    py_trees.display.print_ascii_tree(tree.root)
+    print(py_trees.display.ascii_tree(tree.root))
     assert(len(sequence1.children) == 2)
 
     sequence2 = py_trees.composites.Sequence(name="Sequence2")
@@ -319,7 +319,7 @@ def test_replace_behaviour_tree():
     sequence2.add_child(g)
 
     tree.replace_subtree(sequence1.id, sequence2)
-    py_trees.display.print_ascii_tree(tree.root)
+    print(py_trees.display.ascii_tree(tree.root))
     assert(len(sequence2.children) == 3)
 
 
@@ -339,7 +339,7 @@ def test_tick_tock_behaviour_tree():
     root.add_child(d)
 
     tree = py_trees.trees.BehaviourTree(root)
-    py_trees.display.print_ascii_tree(tree.root)
+    print(py_trees.display.ascii_tree(tree.root))
 
     visitor = py_trees.visitors.DebugVisitor()
     tree.visitors.append(visitor)
@@ -362,7 +362,7 @@ def test_success_failure_tree():
     root.add_child(failure)
     root.add_child(failure2)
     root.add_child(success)
-    py_trees.display.print_ascii_tree(root)
+    print(py_trees.display.ascii_tree(root))
     visitor = py_trees.visitors.DebugVisitor()
     py_trees.tests.tick_tree(root, 1, 1, visitors=[visitor])
 
@@ -388,7 +388,7 @@ def test_tip_simple():
     seq.add_child(b)
 
     tree = py_trees.trees.BehaviourTree(seq)
-    py_trees.display.print_ascii_tree(tree.root)
+    print(py_trees.display.ascii_tree(tree.root))
 
     visitor = py_trees.visitors.DebugVisitor()
     tree.visitors.append(visitor)
@@ -459,7 +459,7 @@ def test_tip_complex():
     sel.add_child(seq2)
 
     tree = py_trees.trees.BehaviourTree(sel)
-    py_trees.display.print_ascii_tree(tree.root)
+    print(py_trees.display.ascii_tree(tree.root))
 
     visitor = py_trees.visitors.DebugVisitor()
     tree.visitors.append(visitor)
@@ -509,7 +509,7 @@ def test_failed_tree():
     root.add_child(f2)
     root.add_child(f3)
     tree = py_trees.trees.BehaviourTree(root)
-    py_trees.display.print_ascii_tree(tree.root)
+    print(py_trees.display.ascii_tree(tree.root))
     tree.tick()
     print("\n--------- Assertions ---------\n")
     print("root.tip().name == Failure 3")

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -8,8 +8,6 @@
 # Imports
 ##############################################################################
 
-import os
-
 import nose.tools
 
 import py_trees
@@ -42,7 +40,7 @@ def test_winds_of_change():
     root.add_child(a)
     root.add_child(b)
     root.add_child(c)
-    py_trees.display.print_ascii_tree(root, 0)
+    print(py_trees.display.ascii_tree(root))
 
     debug_visitor = py_trees.visitors.DebugVisitor()
     snapshot_visitor = py_trees.visitors.SnapshotVisitor()


### PR DESCRIPTION
* [console] decouple `console` module (remove `py_tree` specific fallbacks in symbols)
* [display] consolidates symbols in one place 
* [display] collapse redundant methods for ascii tree generation

Note: this is a minor api change.
