### PR TITLE
[infra] only generate html reports on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           name: Tests
           command: |
             . venv/bin/activate
-            python setup.py nosetests
+            python setup.py nosetests --with-html
 
       - run:
           name: Linters

--- a/package.xml
+++ b/package.xml
@@ -30,9 +30,11 @@
 
   <test_depend>python3-nose</test_depend>
   <test_depend>python3-nose-yanc</test_depend>
-
-  <!-- Not a deb :/ -->
-  <!-- <test_depend>python3-nose-htmloutput</test_depend> -->
+  <!--           not available as a deb yet                     -->
+  <!-- note: don't confuse nose-htmloutput with nosehtmloutput, -->
+  <!--       the latter is a deb and doesn't work on bionic     -->
+  <!--        both are pypi packages, but different             -->
+  <!--  <test_depend>python3-nosehtmloutput</test_depend>       -->
 
   <export>
     <build_type>ament_python</build_type>

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,8 @@ detailed-errors=1
 
 # for colour
 with-yanc=1
-
-with-html=1
+# creates a html report, but unfortunately not available on bionic, so we run this only in the circleci instructions
+# with-html=1
 
 [flake8]
 max-line-length = 299


### PR DESCRIPTION
Bionic doesn't have a deb for `nose-htmloutput` (don't confuse with `nosehtmloutput`, it's a different package that doesn't work). So drop it in general and explicitly call it only in the circle ci configuration.