### PR TITLE
[visitors] snapshot/winds of change functionality collapsed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ Release Notes
 Forthcoming
 -----------
 
+1.3.x (2019-??-??)
+------------------
+
+**Breaking API**
+
+* [visitors] collapsed ``SnapshotVisitor`` and ``WindsOfChangeVisitor`` functionality, `#228 <https://github.com/splintered-reality/py_trees/pull/228>`_
+
+**New Features**
+
+* [visitors] new ``DisplaySnapshotVisitor`` to simplify collection/printing the tree to console, `#228 <https://github.com/splintered-reality/py_trees/pull/228>`_
+
 1.2.2 (2019-08-06)
 ------------------
 * [trees] standalone ``setup()`` method with timer for use on unmanaged trees, `#198 <https://github.com/splintered-reality/py_trees/pull/198>`_

--- a/py_trees/demos/stewardship.py
+++ b/py_trees/demos/stewardship.py
@@ -92,17 +92,6 @@ def pre_tick_handler(behaviour_tree):
     print("\n--------- Run %s ---------\n" % behaviour_tree.count)
 
 
-def post_tick_handler(snapshot_visitor, behaviour_tree):
-    """
-    Prints an ascii tree with the current snapshot status.
-    """
-    print("\n" + py_trees.display.unicode_tree(
-        root=behaviour_tree.root,
-        visited=snapshot_visitor.visited,
-        previously_visited=snapshot_visitor.visited)
-    )
-
-
 def create_tree():
     every_n_success = py_trees.behaviours.SuccessEveryN("EveryN", 5)
     sequence = py_trees.composites.Sequence(name="Sequence")
@@ -147,9 +136,7 @@ def main():
     behaviour_tree = py_trees.trees.BehaviourTree(tree)
     behaviour_tree.add_pre_tick_handler(pre_tick_handler)
     behaviour_tree.visitors.append(py_trees.visitors.DebugVisitor())
-    snapshot_visitor = py_trees.visitors.SnapshotVisitor()
-    behaviour_tree.add_post_tick_handler(functools.partial(post_tick_handler, snapshot_visitor))
-    behaviour_tree.visitors.append(snapshot_visitor)
+    behaviour_tree.visitors.append(py_trees.visitors.DisplaySnapshotVisitor())
     behaviour_tree.setup(timeout=15)
 
     ####################

--- a/py_trees/tests.py
+++ b/py_trees/tests.py
@@ -60,7 +60,7 @@ def tick_tree(root,
             for visitor in visitors:
                 node.visit(visitor)
     if print_snapshot:
-        print(console.green + "\nAscii Tree Snapshot" + console.reset)
+        print(console.green + "\nTree Snapshot" + console.reset)
         print(display.unicode_tree(root=root, show_status=True))
     if print_blackboard:
         print(str(blackboard.Blackboard()))

--- a/py_trees/trees.py
+++ b/py_trees/trees.py
@@ -176,7 +176,7 @@ class BehaviourTree(object):
 
         .. seealso:: :class:`~py_trees.visitors.DebugVisitor`,
             :class:`~py_trees.visitors.SnapshotVisitor`,
-            :class:`~py_trees.visitors.WindsOfChangeVisitor`
+            :class:`~py_trees.visitors.DisplaySnapshotVisitor`
         """
         self.visitors.append(visitor)
 
@@ -405,36 +405,3 @@ class BehaviourTree(object):
         # timeout mechanisms as used in setup()
         for node in self.root.iterate():
             node.shutdown()
-
-##############################################################################
-# Post Tick Handlers
-##############################################################################
-
-
-def setup_tree_unicode_art_debug(tree: BehaviourTree):
-    """
-    Convenience method for configuring a tree to paint unicode art
-    for your tree's snapshot on your console at the end of every tick.
-
-    Args:
-        tree (:class:`~py_trees.trees.BehaviourTree`): the behaviour tree that has just been ticked
-    """
-    def unicode_tree_post_tick_handler(
-        snapshot_visitor: visitors.SnapshotVisitor,
-        tree: BehaviourTree
-    ):
-        print(
-            display.unicode_tree(
-                tree.root,
-                visited=snapshot_visitor.visited,
-                previously_visited=snapshot_visitor.previously_visited
-            )
-        )
-    snapshot_visitor = visitors.SnapshotVisitor()
-    tree.add_visitor(snapshot_visitor)
-    tree.add_post_tick_handler(
-        functools.partial(
-            unicode_tree_post_tick_handler,
-            snapshot_visitor
-        )
-    )

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -652,8 +652,8 @@ def test_pre_post_tick_activity_sequence():
 
 def test_unicode_tree_debug():
     """
-    Just check the code path through to painting ascii art via
-    tree visitors and post-tick handlers is executable
+    Just check the code path through to painting unicode art via
+    tree visitors is executable
     """
     console.banner("Tree Ascii Art")
     root = py_trees.composites.Selector("Selector")
@@ -661,14 +661,16 @@ def test_unicode_tree_debug():
         py_trees.behaviours.Count(
             name="High Priority",
             fail_until=1,
-            running_until=1,
+            running_until=3,
             success_until=10
         )
     )
     root.add_child(py_trees.behaviours.Running(name="Low Priority"))
     tree = py_trees.trees.BehaviourTree(root=root)
-    py_trees.trees.setup_tree_unicode_art_debug(tree)
+    tree.add_visitor(py_trees.visitors.DisplaySnapshotVisitor())
     tree.setup()
+    tree.tick()
+    tree.tick()
     tree.tick()
     # If we got all the way here, that suffices. If we really wished,
     # we could catch stdout and check that.

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -30,8 +30,8 @@ logger = py_trees.logging.Logger("Nosetest")
 ##############################################################################
 
 
-def test_winds_of_change():
-    console.banner("Winds of Change")
+def test_snapshot_visitor():
+    console.banner("Snapshot Visitor")
 
     root = py_trees.composites.Selector(name='Selector')
     a = py_trees.behaviours.Count(name="A")
@@ -44,18 +44,16 @@ def test_winds_of_change():
 
     debug_visitor = py_trees.visitors.DebugVisitor()
     snapshot_visitor = py_trees.visitors.SnapshotVisitor()
-    winds_of_change_visitor = py_trees.visitors.WindsOfChangeVisitor()
 
     for i, result in zip(range(1, 5), [True, False, False, True]):
         py_trees.tests.tick_tree(
             root, i, i,
             visitors=[debug_visitor,
-                      snapshot_visitor,
-                      winds_of_change_visitor],
+                      snapshot_visitor],
             print_snapshot=True
         )
         print("--------- Assertions ---------\n")
-        print("winds_of_change_visitor.changed == {}".format(result))
-        assert(winds_of_change_visitor.changed is result)
+        print("snapshot_visitor.changed == {}".format(result))
+        assert(snapshot_visitor.changed is result)
 
     print("Done")


### PR DESCRIPTION
Additionally, a new `DisplaySnapshotVisitor` to simplify printing out the tree to console.