### PR TITLE
[docs] switch to the better sphinx_autodoc_typehints 

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,7 +49,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
     'sphinxarg.ext',
-    'sphinx_autodoc_annotation',  # type hinting will cause errors without this
+    'sphinx_autodoc_typehints',  # type hinting will cause errors without this
 ]
 ##############################################################################
 # Napolean

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -11,14 +11,13 @@
 ##############################################################################
 
 # install_requires
-enum34;python_version<"3.4"
 pydot
 
 # extras_require[docs]
-Sphinx
-sphinx-argparse
-sphinx_rtd_theme
-sphinx-autodoc-annotation
+Sphinx<2
+sphinx-argparse<0.3
+sphinx_rtd_theme<0.5
+sphinx-autodoc-typehints==1.6.0
 
 # extras_require[test] || tests_require
 nose

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ tests_require = ['nose', 'pydot', 'pytest', 'flake8', 'yanc', 'nose-htmloutput']
 
 extras_require = {} if os.environ.get('AMENT_PREFIX_PATH') else {
     'test': tests_require,
-    'docs': ["Sphinx", "sphinx-argparse", "sphinx_rtd_theme", "sphinx-autodoc-annotation"],
+    'docs': ["Sphinx", "sphinx-argparse", "sphinx_rtd_theme", "sphinx-autodoc-typehints"],
     'debs': ['stdeb', 'twine']
 }
 ##############################

--- a/virtualenv.bash
+++ b/virtualenv.bash
@@ -88,7 +88,11 @@ if [ "${VIRTUAL_ENV}" == "" ]; then
 fi
 
 # Get all dependencies for testing, doc generation
-pip install -e .[docs]
+
+# pip install -e .[docs]
+# we have to restrict versions because of bleeding edge incompatibilities
+pip install -r rtd-requirements.txt
+
 pip install -e .[test]
 pip install -e .[debs]
 


### PR DESCRIPTION
This puts in the typehint link next to an arg (which hasn't itself been given a type) and also makes sure that external docs are properly linked (the old module did not guarantee this). 

Additionally, the variable signatures are sane and not jammed with the typehints rubbish verbatim.

Resolves #234.