### PR TITLE
Blackboard client facade (namespacing)

### DIFF
--- a/tests/test_blackboard_facade.py
+++ b/tests/test_blackboard_facade.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# License: BSD
+#   https://raw.githubusercontent.com/splintered-reality/py_trees/devel/LICENSE
+#
+
+##############################################################################
+# Imports
+##############################################################################
+
+import nose
+
+import py_trees
+import py_trees.console as console
+
+from py_trees.blackboard import Blackboard, BlackboardClient, BlackboardClientFacade
+
+##############################################################################
+# Helpers
+##############################################################################
+
+
+class create_blackboard(object):
+
+    def __enter__(self):
+        self.blackboard = BlackboardClient(name="bb")
+        self.blackboard.register_key("foo", write=True)
+        self.blackboard.foo = "bar"
+        return self.blackboard
+
+    def __exit__(self, unused_type, unused_value, unused_traceback):
+        self.blackboard.unregister(clear=True)
+
+
+##############################################################################
+# Tests
+##############################################################################
+
+
+def test_standalone_blackboard_and_facade():
+    console.banner("Standalone Client & Facade")
+    with create_blackboard() as (blackboard):
+        print('{0}'.format(blackboard))
+        facade = BlackboardClientFacade(prefix="dude_", blackboard=blackboard)
+        facade.register_key(key="bob", write=True)
+        facade.register_key(key="jane", read=True)
+        facade.bob = "cool bloke"
+        assert("cool bloke" == facade.bob)
+        assert(facade.exists("bob"))
+        assert(blackboard.exists("dude_bob"))
+        print('{0}'.format(blackboard))
+        # could test lots more
+
+
+def test_behaviour_and_facade():
+    console.banner("Behaviour & Facade")
+
+    class Foo(py_trees.behaviour.Behaviour):
+        def __init__(self):
+            super().__init__(name="Foo")
+            self.blackboard.register_key("foo", write=True)
+            self.blackboard.foo = "bar"
+            self.agent_blackboard = BlackboardClientFacade(
+                prefix="agent0_",
+                blackboard=self.blackboard
+            )
+            self.agent_blackboard.register_key(key="initial_position", write=True)
+            self.agent_blackboard.initial_position = 5.0
+
+    foo = Foo()
+    assert(Blackboard.get("foo") == "bar")
+    assert(Blackboard.get("agent0_initial_position") == 5.0)
+    print("{}".format(foo.blackboard))


### PR DESCRIPTION
So, this is what the class would look like if it was handling namespacing under the hood for a particular blackboard client.

It works, but I'm really not liking it. This was predicated on the fact that each behaviour is associated with one and only one blackboard - a design constraint introduced by all the tooling to handle lookups from keys to behaviour names and back.

I think a better approach is (but more effort):

*  Permit optional namespacing directly in `BlackboardClient`
* `Behaviour` still creates it's own blackboard as it's default blackboard (`self.blackboard`)
* `Behaviour` has a `create_blackboard(namespace=None)` method that allows a user to create additional blackboards tied to the behaviour
* Under the hood, `Behaviour` stores handles to any/all blackboards it is associated with in a list
* Tooling does lookups on every blackboard in the `Behaviour`'s list to trace what variables are being accessed by the behaviour.

Starting the above in #250.