### PR TITLE
[trees] windows compatible setup signals, fixes #252

### DIFF
--- a/py_trees/trees.py
+++ b/py_trees/trees.py
@@ -69,7 +69,9 @@ def setup(root: behaviour.Behaviour,
         Exception: be ready to catch if any of the behaviours raise an exception
         RuntimeError: in case setup() times out
     """
-    _SIGNAL = signal.SIGUSR1
+    # SIGUSR1 is a better choice since it's a user defined operation, but these
+    # are not available on windows, so overload one of the standard definitions
+    _SIGNAL = signal.SIGINT
 
     def on_timer_timed_out():
         os.kill(os.getpid(), _SIGNAL)


### PR DESCRIPTION
Resolves #252, making up for platforms on which `SIGUSR1` is not available (at least Windows).

Will be released in the upcoming `v1.4.x` release.