### PR TITLE
[blackboard] let the static methods make use of absolute names

### DIFF
--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -1068,12 +1068,11 @@ class Client(object):
         key = Blackboard.absolute_name(super().__getattribute__("namespace"), key)
         super().__getattribute__("remappings")[key] = key if remap_to is None else remap_to
         remapped_key = super().__getattribute__("remappings")[key]
-        Blackboard.metadata.setdefault(remapped_key, KeyMetaData())
         if access == common.Access.READ:
             super().__getattribute__("read").add(key)
+            Blackboard.metadata.setdefault(remapped_key, KeyMetaData())
             Blackboard.metadata[remapped_key].read.add(super().__getattribute__("unique_identifier"))
         elif access == common.Access.WRITE:
-            super().__getattribute__("write").add(key)
             conflicts = set()
             try:
                 for unique_identifier in Blackboard.metadata[remapped_key].exclusive:
@@ -1086,9 +1085,10 @@ class Client(object):
                         )
             except KeyError:
                 pass  # no readers or writers on the key yet
+            super().__getattribute__("write").add(key)
+            Blackboard.metadata.setdefault(remapped_key, KeyMetaData())
             Blackboard.metadata[remapped_key].write.add(super().__getattribute__("unique_identifier"))
         elif access == common.Access.EXCLUSIVE_WRITE:
-            super().__getattribute__("exclusive").add(key)
             try:
                 key_metadata = Blackboard.metadata[remapped_key]
                 conflicts = set()
@@ -1102,6 +1102,8 @@ class Client(object):
                     )
             except KeyError:
                 pass  # no readers or writers on the key yet
+            super().__getattribute__("exclusive").add(key)
+            Blackboard.metadata.setdefault(remapped_key, KeyMetaData())
             Blackboard.metadata[remapped_key].exclusive.add(super().__getattribute__("unique_identifier"))
         else:
             raise TypeError("access argument is of incorrect type [{}]".format(type(access)))
@@ -1120,8 +1122,12 @@ class Client(object):
         Raises:
             KeyError if the key has not been previously registered
         """
+        print("DJS: Unregister Key")
+        print("DJS: Unregister Key: {}".format(key))
         key = Blackboard.absolute_name(super().__getattribute__("namespace"), key)
+        print("DJS: Unregister Key: {}".format(key))
         remapped_key = super().__getattribute__("remappings")[key]
+        print("DJS: Unregister Remapped Key: {}".format(remapped_key))
         super().__getattribute__("read").discard(key)  # doesn't throw exceptions if it not present
         super().__getattribute__("write").discard(key)
         super().__getattribute__("exclusive").discard(key)

--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -230,6 +230,7 @@ class Blackboard(object):
         Return:
             The stored value for the given variable
         """
+        variable_name = Blackboard.absolute_name(Blackboard.separator, variable_name)
         name_components = variable_name.split('.')
         key = name_components[0]
         key_attributes = '.'.join(name_components[1:])
@@ -257,6 +258,7 @@ class Blackboard(object):
         Raises:
             AttributeError: if it is attempting to set a nested attribute tha does not exist.
         """
+        variable_name = Blackboard.absolute_name(Blackboard.separator, variable_name)
         name_components = variable_name.split('.')
         key = name_components[0]
         key_attributes = '.'.join(name_components[1:])
@@ -278,6 +280,7 @@ class Blackboard(object):
             True if the variable was removed, False if it was already absent
         """
         try:
+            key = Blackboard.absolute_name(Blackboard.separator, key)
             del Blackboard.storage[key]
             return True
         except KeyError:
@@ -295,6 +298,7 @@ class Blackboard(object):
             AttributeError: if the client does not have read access to the variable
         """
         try:
+            name = Blackboard.absolute_name(Blackboard.separator, name)
             unused_value = Blackboard.get(name)
             return True
         except KeyError:

--- a/tests/test_blackboard.py
+++ b/tests/test_blackboard.py
@@ -509,7 +509,7 @@ def test_exclusive_write():
     blackboard = py_trees.blackboard.Client(name="Blackboard")
     blackboard.register_key(key="dude", access=py_trees.common.Access.WRITE)
     blackboard.register_key(key="dudette", access=py_trees.common.Access.EXCLUSIVE_WRITE)
-    blackboard_exclusive = py_trees.blackboard.Client(name="Blackboard X")
+    blackboard_exclusive = py_trees.blackboard.Client(name="BlackboardX")
     with nose.tools.assert_raises_regexp(AttributeError, "requested exclusive write"):
         print("Exclusive write requested, but already has a writer - expecting an AttributeError")
         blackboard_exclusive.register_key(key="dude", access=py_trees.common.Access.EXCLUSIVE_WRITE)

--- a/tests/test_blackboard.py
+++ b/tests/test_blackboard.py
@@ -492,7 +492,7 @@ def test_remappings():
 
     print(py_trees.display.unicode_blackboard())
     print(blackboard)
-    blackboard.unregister()
+    blackboard.unregister(clear=True)
 
 
 def test_exclusive_write():
@@ -519,3 +519,20 @@ def test_exclusive_write():
     with nose.tools.assert_raises_regexp(AttributeError, "requested write on"):
         print("Write requested, but already has an exclusive writer - expecting an AttributeError")
         blackboard_exclusive.register_key(key="dudette", access=py_trees.common.Access.WRITE)
+
+    blackboard.unregister(clear=True)
+    blackboard_exclusive.unregister(clear=True)
+
+
+def test_blackboard_static_names():
+    console.banner("Test Absolute Names with Static Methods")
+    print("Set 'foo'")
+    Blackboard.set("foo", "foo")
+    print("Get 'foo' [{}]".format(Blackboard.get("foo")))
+    assert(Blackboard.get("foo") == "foo")
+    assert(Blackboard.get("/foo") == "foo")
+    print("Set '/bar'")
+    Blackboard.set("/bar", "bar")
+    print("Get 'bar' [{}]".format(Blackboard.get("bar")))
+    assert(Blackboard.get("bar") == "bar")
+    assert(Blackboard.get("/bar") == "bar")


### PR DESCRIPTION
FYI @andrewbest-tri

Can now do:
```
Blackboard.set("foo", "foo")
result = Blackboard.get("foo")
result = Blackboard.get("/foo")
```

Also includes a bugfix for registration of keys on the local client *before* conflict checks abort the process.