### PR TITLE
[trees] revert to using user signals if available

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Release Notes
 
 Forthcoming
 -----------
+* [trees] revert to using user signals if available to avoid shenanigans with SIGINT, `#263 <https://github.com/splintered-reality/py_trees/pull/263>`_
 * [trees] play nicely, reset signal handlers after setup, `#262 <https://github.com/splintered-reality/py_trees/pull/262>`_
 * [visitors] bugfix the snapshot visitor to look for exclusive write keys as well
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Release Notes
 
 Forthcoming
 -----------
-* [trees] revert to using user signals if available to avoid shenanigans with SIGINT, `#263 <https://github.com/splintered-reality/py_trees/pull/263>`_
+* [trees] revert to using user signals if available to avoid shenanigans with SIGINT, `#264 <https://github.com/splintered-reality/py_trees/pull/264>`_
 * [trees] play nicely, reset signal handlers after setup, `#262 <https://github.com/splintered-reality/py_trees/pull/262>`_
 * [visitors] bugfix the snapshot visitor to look for exclusive write keys as well
 

--- a/py_trees/trees.py
+++ b/py_trees/trees.py
@@ -70,7 +70,14 @@ def setup(root: behaviour.Behaviour,
     """
     # SIGUSR1 is a better choice since it's a user defined operation, but these
     # are not available on windows, so overload one of the standard definitions
-    _SIGNAL = signal.SIGINT
+    try:
+        _SIGNAL = signal.SIGUSR1
+    except AttributeError:  # windows...
+        # SIGINT can get you into trouble if for example, you are using a
+        # process manager that plays shenanigans with SIGINT. Nonetheless,
+        # it will work in most situations. If a windows user is running into
+        # problems, work with them to resolve it.
+        _SIGNAL = signal.SIGINT
 
     def on_timer_timed_out():
         os.kill(os.getpid(), _SIGNAL)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -556,7 +556,7 @@ def test_tree_setup():
     print("\n--------- Assertions ---------\n")
     print(console.cyan + "Short Timeout: " + console.yellow + "No Visitor" + console.reset)
     with nose.tools.assert_raises(RuntimeError) as context:
-        tree.setup(timeout=2*duration)
+        tree.setup(timeout=2 * duration)
     print("RuntimeError has message with substring 'timed out'")
     assert("timed out" in str(context.exception))
     active_threads = threading.active_count()
@@ -565,7 +565,7 @@ def test_tree_setup():
     print("\n--------- Assertions ---------\n")
     print(console.cyan + "Short timeout: " + console.yellow + "No Visitor" + console.reset)
     try:
-        tree.setup(timeout=4*duration)
+        tree.setup(timeout=4 * duration)
     except RuntimeError:
         assert False, "should not have timed out"
     active_threads = threading.active_count()
@@ -575,7 +575,7 @@ def test_tree_setup():
     print(console.cyan + "Long Timeout: " + console.yellow + "With Visitor" + console.reset)
     visitor = SetupVisitor()
     with nose.tools.assert_raises(RuntimeError) as context:
-        tree.setup(timeout=2*duration, visitor=visitor)
+        tree.setup(timeout=2 * duration, visitor=visitor)
     print("RuntimeError has message with substring 'timed out'")
     assert("timed out" in str(context.exception))
     active_threads = threading.active_count()
@@ -585,7 +585,7 @@ def test_tree_setup():
     print(console.cyan + "Long timeout: " + console.yellow + "With Visitor" + console.reset)
     visitor = SetupVisitor()
     try:
-        tree.setup(timeout=4*duration, visitor=visitor)
+        tree.setup(timeout=4 * duration, visitor=visitor)
     except RuntimeError:
         assert False, "should not have timed out"
     active_threads = threading.active_count()
@@ -638,7 +638,7 @@ def test_pre_post_tick_activity_sequence():
         "visitor.finalise()",
         "post_tick_handler",
         "one_shot_post_tick_handler"
-        ]
+    ]
     print("")
     assert(len(breadcrumbs) == len(expected_breadcrumbs))
     for expected, actual in zip(expected_breadcrumbs, breadcrumbs):


### PR DESCRIPTION
This avoids shenanigans with SIGINT, particularly if your process
manager is doing its own thing and running interference.

Resolves #263.