### PR TITLE
Enum agnostic local and remote activity view display

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Forthcoming
 -----------
 * ...
 
+2.0.5 (2019-12-25)
+------------------
+* [display] enum agnostic display for local and remote activity view displays
+
 2.0.4 (2019-11-25)
 ------------------
 * [display] optional show_title in unicode_blackboard_activity_stream

--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -125,7 +125,7 @@ class ActivityItem(object):
             key,
             client_name: str,
             client_id: uuid.UUID,
-            activity_type: ActivityType,
+            activity_type: str,
             previous_value: typing.Any=None,
             current_value: typing.Any=None):
         # TODO validity checks for values passed/not passed on the
@@ -947,7 +947,8 @@ class Client(object):
             key=key,
             client_name=super().__getattribute__("name"),
             client_id=super().__getattribute__("unique_identifier"),
-            activity_type=activity_type,
+            # use strings here, so displaying the streams is agnostic of the enum
+            activity_type=activity_type.value,
             previous_value=previous_value,
             current_value=current_value
         )

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,9 +14,11 @@ it will pick up the nosetests configuration in `setup.cfg`.
 # All Tests via SetupTools (indirectly)
 $ python setup.py nosetests
 # All Tests via Nosetest (directly)
-$ nosetests ./tests
+$ nosetests -s ./tests
+# A single test module
+$ nosetests -s tests/test_oneshot.py
 # A single test
-$ nosetests tests/test_oneshot.py
+$ nosetests -s tests/test_blackboard.py:test_activity_stream
 ```
 
 If not in the virtualenv and in a dual python environment, e.g. Ubuntu bionic,

--- a/tests/test_blackboard.py
+++ b/tests/test_blackboard.py
@@ -305,7 +305,7 @@ def test_activity_stream():
         py_trees.blackboard.ActivityType.UNSET,
     ]
     for item, expected in zip(Blackboard.activity_stream.data, expected_types):
-        assert(item.activity_type == expected)
+        assert(item.activity_type == expected.value)
     blackboard.unregister(clear=True)
 
 


### PR DESCRIPTION
This helps the remote side construct an activity view display without having to convert back and forth from middleware messages to enums. Just something with the required fields will do.