### PR TITLE
Blackboard performance optimisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ nosetests.html
 eclipse
 *.vscode
 dump.json
+tests/blackboard.cprofile
 

--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -1032,11 +1032,10 @@ class Client(object):
             super().__getattribute__("write"),
             super().__getattribute__("exclusive")
         ):
-            separated_namespaces = key.split("/")[:-1]
-            if len(separated_namespaces) > 1:
-                for index in range(2, len(separated_namespaces) + 1):
-                    namespace = "/".join(separated_namespaces[0:index])
-                    super().__getattribute__("namespaces").add(namespace)
+            namespace = key.rsplit("/", 1)[0]
+            while namespace:
+                super().__getattribute__("namespaces").add(namespace)
+                namespace = namespace.rsplit("/", 1)[0]
 
     def __str__(self):
         indent = "  "

--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -1097,7 +1097,8 @@ class Client(object):
             clear: remove key-values pairs from the blackboard
         """
         for key in itertools.chain(set(self.read), set(self.write), set(self.exclusive)):
-            self.unregister_key(key=key, clear=clear)
+            self.unregister_key(key=key, clear=clear, update_namespace_cache=False)
+        self._update_namespaces()
 
     def verify_required_keys_exist(self):
         """
@@ -1214,13 +1215,20 @@ class Client(object):
             super().__getattribute__("required").add(key)
         self._update_namespaces()
 
-    def unregister_key(self, key: str, clear: bool=True):
+    def unregister_key(
+            self,
+            key: str,
+            clear: bool=True,
+            update_namespace_cache: bool=True):
         """
         Unegister a key associated with this client.
 
         Args:
             key: key to unregister
             clear: remove key-values pairs from the blackboard
+            update_namespace_cache: disable if you are batching
+
+        A method that batches calls to this method is :meth:`unregister_all_keys()`.
 
         Raises:
             KeyError if the key has not been previously registered
@@ -1245,7 +1253,8 @@ class Client(object):
                 except KeyError:
                     pass  # perfectly legitimate for a registered key to not exist on the blackboard
         del super().__getattribute__("remappings")[key]
-        self._update_namespaces()
+        if update_namespace_cache:
+            self._update_namespaces()
 
 
 class IntermediateVariableFetcher(object):

--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -380,9 +380,33 @@ class Blackboard(object):
 
     @staticmethod
     def absolute_name(namespace: str, name: str) -> str:
-        # assumptions (that expedite checks)
-        #  - namespace already starts with "/"
+        """
+        Generate the fully qualified key name from namespace and name arguments.
 
+        **Examples**
+
+        .. code-block:: python
+
+            '/' + 'foo'  = '/foo'
+            '/' + '/foo' = '/foo'
+            '/foo' + 'bar' = '/foo/bar'
+            '/foo/' + 'bar' = '/foo/bar'
+            '/foo' + '/bar' = '/foo/bar'
+            '/foo' + 'foo/bar' = '/foo/foo/bar'
+
+        Args:
+            namespace: namespace the key should be embedded in
+            name: key name (relative or absolute)
+
+        Returns:
+            the absolute name
+
+        .. warning::
+
+            To expedite the method call (it's used with high frequency
+            in blackboard key lookups), no checks are made to ensure
+            the namespace argument leads with a "/"
+        """
         # it's already absolute
         if name.startswith(namespace):
             return name
@@ -390,6 +414,48 @@ class Blackboard(object):
         namespace = namespace if namespace.endswith(Blackboard.separator) else namespace + Blackboard.separator
         name = name.strip(Blackboard.separator)
         return "{}{}".format(namespace, name)
+
+    @staticmethod
+    def relative_name(namespace: str, name: str) -> str:
+        """
+        **Examples**
+
+        .. code-block:: python
+
+            '/' + 'foo'  = '/foo'
+            '/' + '/foo' = '/foo'
+            '/foo' + 'bar' = '/foo/bar'
+            '/foo/' + 'bar' = '/foo/bar'
+            '/foo' + '/bar' = '/foo/bar'
+            '/foo' + 'foo/bar' = '/foo/foo/bar'
+
+        Args:
+            namespace: namespace the key should be embedded in
+            name: key name (relative or absolute)
+
+        Returns:
+            the absolute name
+
+        Raises:
+            ValueError if the key is not in the specified namespace
+
+        .. warning::
+
+            To expedite the method call (it's used with high frequency
+            in blackboard key lookups), no checks are made to ensure
+            the namespace argument leads with a "/"
+        """
+        # it's already relative
+        if not name.startswith(Blackboard.separator):
+            return name
+        # remove leading and trailing separators
+        namespace = namespace if namespace.endswith(Blackboard.separator) else namespace + Blackboard.separator
+        if name.startswith(namespace):
+            return name.lstrip(namespace)
+        else:
+            raise ValueError("key '{}' is not in namespace '{}'".format(
+                name, namespace)
+            )
 
 
 class Client(object):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ tests_require = ['nose', 'pydot', 'pytest', 'flake8', 'yanc', 'nose-htmloutput']
 extras_require = {} if os.environ.get('AMENT_PREFIX_PATH') else {
     'test': tests_require,
     'docs': ["Sphinx", "sphinx-argparse", "sphinx_rtd_theme", "sphinx-autodoc-typehints"],
-    'debs': ['stdeb', 'twine']
+    'debs': ['pyprof2calltree', 'stdeb', 'twine']
 }
 ##############################
 # Pull in __version__

--- a/tests/benchmark_blackboard.py
+++ b/tests/benchmark_blackboard.py
@@ -50,9 +50,10 @@ class create_blackboards(object):
 
 def benchmark_registration():
     console.banner("Registration Benchmarks (x1000)")
+    start_time = None
     print("No Remaps")
     with create_blackboards() as (root, parameters):
-        width = max(len(root.name), len(parameters.name))
+        width = max(len(root.name), len(parameters.name), len("Unregister"))
         for blackboard in (root, parameters):
             start_time = time.monotonic()
             for i in range(0, 1000):
@@ -62,6 +63,9 @@ def benchmark_registration():
                 )
             duration = time.monotonic() - start_time
             print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
+        start_time = time.monotonic()
+    duration = time.monotonic() - start_time
+    print(" - " + console.cyan + "{0: <{1}}".format("Unregister", width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
 
     with create_blackboards() as (root, parameters):
         remaps = {i: "/state/{}".format(i) for i in range(0, 1000)}
@@ -76,6 +80,9 @@ def benchmark_registration():
                 )
             duration = time.monotonic() - start_time
             print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
+        start_time = time.monotonic()
+    duration = time.monotonic() - start_time
+    print(" - " + console.cyan + "{0: <{1}}".format("Unregister", width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
 
 
 def benchmark_read():
@@ -87,32 +94,32 @@ def benchmark_read():
             for blackboard in (root, parameters):
                 for i in range(0, 1000):
                     if with_remaps:
-                        remaps = {i: "/state/{}/{}".format(blackboard.name.lower(), i) for i in range(0, 1000)}
+                        remaps = {i: "/state/{}/colander_{}".format(blackboard.name.lower(), i) for i in range(0, 1000)}
                         suffix = " with Remaps"
                         blackboard.register_key(
-                            key=str(i),
+                            key="colander_{}".format(i),
                             access=py_trees.common.Access.READ,
                             remap_to=remaps[i]
                         )
                     else:
                         suffix = ""
                         blackboard.register_key(
-                            key=str(i),
+                            key="colander_{}".format(i),
                             access=py_trees.common.Access.READ,
                         )
             for i in range(0, 1000):
                 if with_remaps:
                     for blackboard in (root, parameters):
-                        py_trees.blackboard.Blackboard.set("/state/{}/{}".format(blackboard.name.lower(), i), i)
+                        py_trees.blackboard.Blackboard.set("/state/{}/colander_{}".format(blackboard.name.lower(), i), i)
                 else:
-                    py_trees.blackboard.Blackboard.set("/{}".format(i), i)
-                    py_trees.blackboard.Blackboard.set("/parameters/{}".format(i), i)
+                    py_trees.blackboard.Blackboard.set("/colander_{}".format(i), i)
+                    py_trees.blackboard.Blackboard.set("/parameters/colander_{}".format(i), i)
             relative_names = {}
             absolute_names = {"Root": {}, "Namespaced": {}}
             for i in range(0, 1000):
-                relative_names[i] = str(i)
-                absolute_names["Root"][i] = "/{}".format(str(i))
-                absolute_names["Namespaced"][i] = "/parameters/{}".format(str(i))
+                relative_names[i] = "colander_{}".format(i)
+                absolute_names["Root"][i] = "/colander_{}".format(i)
+                absolute_names["Namespaced"][i] = "/parameters/colander_{}".format(i)
             print("Relative Names" + suffix)
             for blackboard in (root, parameters):
                 start_time = time.monotonic()
@@ -131,7 +138,7 @@ def benchmark_read():
                 duration = time.monotonic() - start_time
                 print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
     _impl(with_remaps=False)
-    _impl(with_remaps=True)
+    # _impl(with_remaps=True)
 
 
 def benchmark_write():
@@ -185,6 +192,9 @@ def benchmark_write():
 ##############################################################################
 # Main
 ##############################################################################
+
+# To profile this code:
+#   python -m cProfile -s cumtime benchmark_blackboard.py
 
 
 if __name__ == '__main__':

--- a/tests/benchmark_blackboard.py
+++ b/tests/benchmark_blackboard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # License: BSD
 #   https://raw.githubusercontent.com/splintered-reality/py_trees/devel/LICENSE
@@ -8,7 +8,6 @@
 # Imports
 ##############################################################################
 
-import nose
 import time
 
 import py_trees
@@ -49,7 +48,7 @@ class create_blackboards(object):
 ##############################################################################
 
 
-def test_registration():
+def benchmark_registration():
     console.banner("Registration Benchmarks (x1000)")
     print("No Remaps")
     with create_blackboards() as (root, parameters):
@@ -77,10 +76,9 @@ def test_registration():
                 )
             duration = time.monotonic() - start_time
             print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
-    assert(True)
 
 
-def test_read():
+def benchmark_read():
     console.banner("Read Benchmarks (x1000)")
 
     def _impl(with_remaps=False):
@@ -134,10 +132,9 @@ def test_read():
                 print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
     _impl(with_remaps=False)
     _impl(with_remaps=True)
-    assert(True)
 
 
-def test_write():
+def benchmark_write():
     console.banner("Write Benchmarks (x1000)")
 
     def _impl(with_remaps=False):
@@ -184,4 +181,13 @@ def test_write():
                 print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
     _impl(with_remaps=False)
     _impl(with_remaps=True)
-    assert(True)
+
+##############################################################################
+# Main
+##############################################################################
+
+
+if __name__ == '__main__':
+    benchmark_registration()
+    benchmark_read()
+    benchmark_write()

--- a/tests/profile_blackboard
+++ b/tests/profile_blackboard
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python3 -m cProfile -s cumtime -o blackboard.cprofile benchmark_blackboard.py
+pyprof2calltree -k -i blackboard.cprofile

--- a/tests/test_blackboard.py
+++ b/tests/test_blackboard.py
@@ -150,6 +150,39 @@ def test_delayed_register_key():
             assert(bar.other == 1)
 
 
+def test_is_registered():
+    console.banner("Is Registered")
+    blackboard = create_blackboard_foo(namespace="aha")
+    print(blackboard)
+    for key, access in {
+        ('bar', py_trees.common.Access.READ),
+        ('foo', py_trees.common.Access.WRITE),
+        ('dude', py_trees.common.Access.WRITE),
+        ('/aha/bar', py_trees.common.Access.READ),
+        ('/aha/foo', py_trees.common.Access.WRITE),
+        ('/aha/dude', py_trees.common.Access.WRITE),
+    }:
+        result = blackboard.is_registered(key)
+        print("is_registered({}).......[{}][True]".format(key, result))
+        assert(result is True)
+        result = blackboard.is_registered(key, access)
+        print("is_registered({}, {}).......[{}][True]".format(key, access, result))
+        assert(result is True)
+        access = py_trees.common.Access.READ if access == py_trees.common.Access.WRITE else py_trees.common.Access.WRITE
+        result = blackboard.is_registered(key, access)
+        print("is_registered({}, {}).......[{}][False]".format(key, access, result))
+        assert(result is False)
+    for key in {'/aha/foobar', '/aha/dudette'}:
+        result = blackboard.is_registered(key)
+        print("is_registered({}).......[{}][False]".format(key, result))
+        assert(result is False)
+    for key in {'/foo', '/dude'}:
+        with nose.tools.assert_raises(ValueError):
+            print("[{}][{}]..........Expecting ValueError".format(key, "/aha"))
+            blackboard.is_registered(key)
+    blackboard.unregister(clear=True)
+
+
 def test_key_exists():
     console.banner("Key Exists")
     for create in [create_blackboards, create_namespaced_blackboards]:
@@ -416,8 +449,6 @@ def test_absolute_name():
         ("/", "/foo", "/foo"),
         ("/foo", "bar", "/foo/bar"),
         ("/foo/", "bar", "/foo/bar"),
-        ("/foo", "/bar", "/foo/bar"),
-        ("/foo/", "/bar", "/foo/bar"),
         ("/foo/", "/foo/bar", "/foo/bar"),
         ("/foo/", "foo/bar", "/foo/foo/bar"),
     ]
@@ -429,6 +460,12 @@ def test_absolute_name():
             Blackboard.absolute_name(namespace, name)
         ))
         assert(absolute_name == Blackboard.absolute_name(namespace, name))
+
+    namespace = "/foo"
+    name = "/bar"
+    with nose.tools.assert_raises(ValueError):
+        print("[{}][{}]..........Expecting ValueError".format(namespace, name))
+        Blackboard.absolute_name(namespace, name)
 
 
 def test_relative_name():

--- a/tests/test_blackboard.py
+++ b/tests/test_blackboard.py
@@ -177,9 +177,9 @@ def test_is_registered():
         print("is_registered({}).......[{}][False]".format(key, result))
         assert(result is False)
     for key in {'/foo', '/dude'}:
-        with nose.tools.assert_raises(ValueError):
-            print("[{}][{}]..........Expecting ValueError".format(key, "/aha"))
-            blackboard.is_registered(key)
+        result = blackboard.is_registered(key)
+        print("is_registered({}).......[{}][False]".format(key, result))
+        assert(result is False)
     blackboard.unregister(clear=True)
 
 
@@ -447,6 +447,7 @@ def test_absolute_name():
         # namespace, name, absolute name
         ("/", "foo", "/foo"),
         ("/", "/foo", "/foo"),
+        ("/foo", "/bar", "/bar"),  # ignores the namespace
         ("/foo", "bar", "/foo/bar"),
         ("/foo/", "bar", "/foo/bar"),
         ("/foo/", "/foo/bar", "/foo/bar"),
@@ -460,12 +461,6 @@ def test_absolute_name():
             Blackboard.absolute_name(namespace, name)
         ))
         assert(absolute_name == Blackboard.absolute_name(namespace, name))
-
-    namespace = "/foo"
-    name = "/bar"
-    with nose.tools.assert_raises(ValueError):
-        print("[{}][{}]..........Expecting ValueError".format(namespace, name))
-        Blackboard.absolute_name(namespace, name)
 
 
 def test_relative_name():

--- a/tests/test_blackboard.py
+++ b/tests/test_blackboard.py
@@ -431,6 +431,39 @@ def test_absolute_name():
         assert(absolute_name == Blackboard.absolute_name(namespace, name))
 
 
+def test_relative_name():
+    console.banner("Relative Names")
+    # should use Blackboard.separator here, but it's a pita - long and unreadable
+    # just update this if the separator ever changes
+    test_tuples = [
+        # namespace, name, relative name
+        ("/", "foo", "foo"),
+        ("/", "/foo", "foo"),
+        ("/foo", "bar", "bar"),
+        ("/foo/", "bar", "bar"),
+        ("/foo", "/foo/bar", "bar"),
+        ("/foo/", "/foo/bar", "bar"),
+    ]
+    for (namespace, name, absolute_name) in test_tuples:
+        print("[{}][{}]..........[{}][{}]".format(
+            namespace,
+            name,
+            absolute_name,
+            Blackboard.absolute_name(namespace, name)
+        ))
+        assert(absolute_name == Blackboard.relative_name(namespace, name))
+
+    namespace = "/bar"
+    name = "/foo/bar"
+    print("[{}][{}]..........ValueError".format(namespace, name))
+    nose.tools.assert_raises(
+        ValueError, Blackboard.relative_name, namespace, name
+    )
+    with nose.tools.assert_raises(ValueError):
+        print("[{}][{}]..........Expecting ValueError".format(namespace, name))
+        Blackboard.relative_name(namespace, name)
+
+
 def test_namespaced_dot_access():
     console.banner("Namespaced Dot Access")
     blackboard = py_trees.blackboard.Client(name="Blackboard")

--- a/tests/test_blackboard_benchmarks.py
+++ b/tests/test_blackboard_benchmarks.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+#
+# License: BSD
+#   https://raw.githubusercontent.com/splintered-reality/py_trees/devel/LICENSE
+#
+
+##############################################################################
+# Imports
+##############################################################################
+
+import nose
+import time
+
+import py_trees
+import py_trees.console as console
+
+##############################################################################
+# Helpers
+##############################################################################
+
+
+class Motley(object):
+    """
+    To test nested access on the blackboard
+    """
+    def __init__(self):
+        self.nested = "nested"
+
+
+class create_blackboards(object):
+
+    def __enter__(self):
+        self.root = py_trees.blackboard.Client(
+            name="Root"
+        )
+        self.parameters = py_trees.blackboard.Client(
+            name="Namespaced",
+            namespace="parameters"
+        )
+        return (self.root, self.parameters)
+
+    def __exit__(self, unused_type, unused_value, unused_traceback):
+        self.parameters.unregister(clear=True)
+        self.root.unregister(clear=True)
+
+
+##############################################################################
+# Tests
+##############################################################################
+
+
+def test_registration():
+    console.banner("Registration Benchmarks (x1000)")
+    print("No Remaps")
+    with create_blackboards() as (root, parameters):
+        width = max(len(root.name), len(parameters.name))
+        for blackboard in (root, parameters):
+            start_time = time.monotonic()
+            for i in range(0, 1000):
+                blackboard.register_key(
+                    key=str(i),
+                    access=py_trees.common.Access.READ,
+                )
+            duration = time.monotonic() - start_time
+            print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
+
+    with create_blackboards() as (root, parameters):
+        remaps = {i: "/state/{}".format(i) for i in range(0, 1000)}
+        print("Remaps (x1000)")
+        for blackboard in (root, parameters):
+            start_time = time.monotonic()
+            for i in range(0, 1000):
+                blackboard.register_key(
+                    key=str(i),
+                    access=py_trees.common.Access.READ,
+                    remap_to=remaps[i]
+                )
+            duration = time.monotonic() - start_time
+            print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
+    assert(True)
+
+
+def test_read():
+    console.banner("Read Benchmarks (x1000)")
+
+    def _impl(with_remaps=False):
+        with create_blackboards() as (root, parameters):
+            width = max(len(root.name), len(parameters.name))
+            for blackboard in (root, parameters):
+                for i in range(0, 1000):
+                    if with_remaps:
+                        remaps = {i: "/state/{}/{}".format(blackboard.name.lower(), i) for i in range(0, 1000)}
+                        suffix = " with Remaps"
+                        blackboard.register_key(
+                            key=str(i),
+                            access=py_trees.common.Access.READ,
+                            remap_to=remaps[i]
+                        )
+                    else:
+                        suffix = ""
+                        blackboard.register_key(
+                            key=str(i),
+                            access=py_trees.common.Access.READ,
+                        )
+            for i in range(0, 1000):
+                if with_remaps:
+                    for blackboard in (root, parameters):
+                        py_trees.blackboard.Blackboard.set("/state/{}/{}".format(blackboard.name.lower(), i), i)
+                else:
+                    py_trees.blackboard.Blackboard.set("/{}".format(i), i)
+                    py_trees.blackboard.Blackboard.set("/parameters/{}".format(i), i)
+            relative_names = {}
+            absolute_names = {"Root": {}, "Namespaced": {}}
+            for i in range(0, 1000):
+                relative_names[i] = str(i)
+                absolute_names["Root"][i] = "/{}".format(str(i))
+                absolute_names["Namespaced"][i] = "/parameters/{}".format(str(i))
+            print("Relative Names" + suffix)
+            for blackboard in (root, parameters):
+                start_time = time.monotonic()
+                foo = 0
+                for i in range(0, 1000):
+                    foo += blackboard.get(relative_names[i])
+                duration = time.monotonic() - start_time
+                print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
+            print("Absolute Names" + suffix)
+            for blackboard in (root, parameters):
+                names = absolute_names[blackboard.name]
+                start_time = time.monotonic()
+                foo = 0
+                for i in range(0, 1000):
+                    foo += blackboard.get(names[i])
+                duration = time.monotonic() - start_time
+                print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
+    _impl(with_remaps=False)
+    _impl(with_remaps=True)
+    assert(True)
+
+
+def test_write():
+    console.banner("Write Benchmarks (x1000)")
+
+    def _impl(with_remaps=False):
+        with create_blackboards() as (root, parameters):
+            width = max(len(root.name), len(parameters.name))
+            for blackboard in (root, parameters):
+                for i in range(0, 1000):
+                    if with_remaps:
+                        remaps = {i: "/state/{}/{}".format(blackboard.name.lower(), i) for i in range(0, 1000)}
+                        suffix = " with Remaps"
+                        blackboard.register_key(
+                            key=str(i),
+                            access=py_trees.common.Access.WRITE,
+                            remap_to=remaps[i]
+                        )
+                    else:
+                        suffix = ""
+                        blackboard.register_key(
+                            key=str(i),
+                            access=py_trees.common.Access.WRITE,
+                        )
+            relative_names = {}
+            absolute_names = {"Root": {}, "Namespaced": {}}
+            for i in range(0, 1000):
+                relative_names[i] = str(i)
+                absolute_names["Root"][i] = "/{}".format(str(i))
+                absolute_names["Namespaced"][i] = "/parameters/{}".format(str(i))
+            print("Relative Names" + suffix)
+            for blackboard in (root, parameters):
+                start_time = time.monotonic()
+                foo = 0
+                for i in range(0, 1000):
+                    foo += blackboard.set(relative_names[i], i)
+                duration = time.monotonic() - start_time
+                print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
+            print("Absolute Names" + suffix)
+            for blackboard in (root, parameters):
+                names = absolute_names[blackboard.name]
+                start_time = time.monotonic()
+                foo = 0
+                for i in range(0, 1000):
+                    foo += blackboard.set(names[i], i)
+                duration = time.monotonic() - start_time
+                print(" - " + console.cyan + "{0: <{1}}".format(blackboard.name, width) + console.reset + ": " + console.yellow + "{0:.3f}".format(duration) + console.reset)
+    _impl(with_remaps=False)
+    _impl(with_remaps=True)
+    assert(True)

--- a/virtualenv.bash
+++ b/virtualenv.bash
@@ -69,6 +69,7 @@ install_package ()
 ##############################################################################
 
 install_package virtualenvwrapper || return
+install_package kcachegrind || return
 
 # To use the installed python3
 VERSION="--python=/usr/bin/python3"


### PR DESCRIPTION
Resolves: #266

**Results**

For sets of keys in the order of 1000

* read/write operations drop from 20ms to 2ms
* registration/unregistration drops from hundreds of milliseconds to 2-3ms
  * except when removing individual keys

**Content**

* Don't use set concatenation in critical methods - it isn't wearing a colander, so it's evil
* Faster algorithm for rebuilding the entire namespace cache
* Only clear the cache once when clearing all keys in one batch
* Completely rebuild the namespace cache only when necessary (adding keys can be smart, clearing keys - we rebuild)

**Additional Goodies**

* Also includes an `is_registered` lookup function for the client so that users don't have to keep track of what's registered and what is not