### PR TITLE
[composites] protect against multiple parents

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Release Notes
 
 Forthcoming
 -----------
-* ...
+* [composites] protect against adding a child to multiple parents, `#281 <https://github.com/splintered-reality/py_trees/pull/281>`_
 
 2.0.11 (2020-03-01)
 -------------------

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -118,7 +118,8 @@ class Composite(behaviour.Behaviour):
             child (:class:`~py_trees.behaviour.Behaviour`): child to add
 
         Raises:
-            TypeError: if the provided child is not an instance of :class:`~py_trees.behaviour.Behaviour`
+            TypeError: if the child is not an instance of :class:`~py_trees.behaviour.Behaviour`
+            RuntimeError: if the child already has a parent
 
         Returns:
             uuid.UUID: unique id of the child
@@ -126,6 +127,8 @@ class Composite(behaviour.Behaviour):
         if not isinstance(child, behaviour.Behaviour):
             raise TypeError("children must be behaviours, but you passed in {}".format(type(child)))
         self.children.append(child)
+        if child.parent is not None:
+            raise RuntimeError("behaviour '{}' already has parent '{}'".format(child.name, child.parent.name))
         child.parent = self
         return child.id
 

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -68,3 +68,15 @@ def test_composite_errors():
         root.add_child(5.0)
         print("TypeError has message with substring 'behaviours'")
         assert("behaviours" in str(context.exception))
+
+
+def test_protect_against_multiple_parents():
+    console.banner("Protect Against Multiple Parents")
+    child = py_trees.behaviours.Success()
+    first_parent = py_trees.composites.Selector()
+    second_parent = py_trees.composites.Sequence()
+    with nose.tools.assert_raises(RuntimeError):
+        print("Adding a child to two parents")
+        print("Expecting a RuntimeError")
+        for parent in [first_parent, second_parent]:
+            parent.add_child(child)

--- a/tests/test_parallels.py
+++ b/tests/test_parallels.py
@@ -49,7 +49,7 @@ def test_parallel_failure():
 
     failure = py_trees.behaviours.Failure("Failure")
     success = py_trees.behaviours.Success("Success")
-    for child, synchronise  in itertools.product([success, failure], [True, False]):
+    for child, synchronise in itertools.product([success, failure], [True, False]):
         policy = py_trees.common.ParallelPolicy.SuccessOnSelected(children=[child], synchronise=synchronise)
         root = py_trees.composites.Parallel("Parallel", policy=policy)
         root.add_child(failure)
@@ -65,6 +65,10 @@ def test_parallel_failure():
         assert(failure.status == py_trees.common.Status.FAILURE)
         print("success.status == py_trees.common.Status.SUCCESS")
         assert(success.status == py_trees.common.Status.SUCCESS)
+
+        # cleanup so they can be added again
+        root.remove_child(failure)
+        root.remove_child(success)
 
 
 def test_parallel_success():


### PR DESCRIPTION
Have seen people try to add behaviours to multiple parents (thinking re-use of code).

Children are _not copied_ when added to a parent. This protects against that by throwing an exception and notifying the user with an appropriate error message.