### PR TITLE
[blackboard] bugfix metadata not created on static set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Release Notes
 
 Forthcoming
 -----------
-* ...
+* [blackboard] bugfix metadata not created on static set, `#286 <https://github.com/splintered-reality/py_trees_ros/pull/286>`_
 
 2.0.13 (2020-03-24)
 -------------------

--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -267,6 +267,7 @@ class Blackboard(object):
             Blackboard.storage[key] = value
         else:
             setattr(Blackboard.storage[key], key_attributes, value)
+        Blackboard.metadata.setdefault(key, KeyMetaData())
 
     @staticmethod
     def unset(key: str):


### PR DESCRIPTION
This is to fix:

```
#!/usr/bin/env python3

import functools
import py_trees


if __name__ == '__main__':
    KEY_0 = "/Agents/agent0/position_scene"
    KEY_1 = "/Agents/agent1/position_scene"
    KEY_3 = "foo"

    py_trees.blackboard.Blackboard.set(KEY_0, 0)
    py_trees.blackboard.Blackboard.set(KEY_1, 1)
    py_trees.blackboard.Blackboard.set(KEY_3, "bar")
    print(py_trees.display.unicode_blackboard())
    # I would expect to have keys here, but I dont!

    client = py_trees.blackboard.Client(name="foo_client", namespace="foo")
    client.register_key(KEY_3, access=py_trees.common.Access.WRITE)
    client.foo = "1"
    print(py_trees.display.unicode_blackboard())

    # This is the same as above but with a client rather than global
    client2 = py_trees.blackboard.Client(name="foo_client_2")
    client2.register_key(KEY_0, access=py_trees.common.Access.WRITE)
    client2.set(KEY_0, "Changed")
    print(py_trees.display.unicode_blackboard())
```

Keys were there (which was why tests worked), just not showing up in the display method.