### PR TITLE
Chain-able add_children for easy coding

### DIFF
--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -144,6 +144,7 @@ class Composite(behaviour.Behaviour):
         """
         for child in children:
             self.add_child(child)
+        return self
 
     def remove_child(self, child):
         """


### PR DESCRIPTION
Usage: create, add in single line of code
my_sequence = Sequence('MySequence').add_children([childA, childB]
Original code takes 2 lines to do same:
my_sequence = Sequence('MySequence')
my_sequence.add_children([childA, childB])
PS. I know this can be already done in one line my_sequence = Sequence(name='MySequence', children=[childA, childB]), just suggesting an alternative option