### PR TITLE
fix static sequences

### DIFF
--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -423,6 +423,7 @@ class Sequence(Composite):
             try:
                 # advance if there is 'next' sibling
                 self.current_child = self.children[index + 1]
+                index += 1
             except IndexError:
                 pass
 

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -10,6 +10,7 @@
 
 import py_trees
 import py_trees.console as console
+import typing
 
 ##############################################################################
 # Logging Level
@@ -37,6 +38,52 @@ def assert_details(text, expected, result):
 ##############################################################################
 # Tests
 ##############################################################################
+
+
+def test_static_sequence_successes():
+    console.banner('Static Sequence Successes')
+    assert_banner()
+
+    success1 = py_trees.behaviours.Success(name="Success1")
+    success2 = py_trees.behaviours.Success(name="Success2")
+    success3 = py_trees.behaviours.Success(name="Success3")
+    success4 = py_trees.behaviours.Success(name="Success4")
+
+    children = [
+        success1,
+        success2,
+        success3,
+        success4,
+    ]
+    root = py_trees.composites.Sequence(name="Sequence", children=children)
+
+    root.tick_once()
+
+    assert_details("Current Child", success4.name, root.current_child.name)
+    assert root.tip().name == success4.name, 'should execute all 4 nodes of this Sequence'
+
+
+def test_static_sequence_with_failure():
+    console.banner('Static Sequence With Failure')
+    assert_banner()
+
+    success1 = py_trees.behaviours.Success(name="Success1")
+    success2 = py_trees.behaviours.Success(name="Success2")
+    failure = py_trees.behaviours.Failure(name="Failure")
+    success3 = py_trees.behaviours.Success(name="Success3")
+
+    children = [
+        success1,
+        success2,
+        failure,
+        success3,
+    ]
+    root = py_trees.composites.Sequence(name="Sequence", children=children)
+
+    root.tick_once()
+
+    assert_details("Current Child", failure.name, root.current_child.name)
+    assert root.tip().name == failure.name, 'should execute first 2 nodes of this Sequence and fail'
 
 
 def test_tick_add_with_current_child():

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -10,7 +10,6 @@
 
 import py_trees
 import py_trees.console as console
-import typing
 
 ##############################################################################
 # Logging Level


### PR DESCRIPTION
My team noticed a new bug in Sequence execution when we were upgrading py_trees from a version pre-2.0.15 to the current one. I added what seems to be a sensible change and two tests which show how it was broken before.

I noticed that prior to this change, if, for example, you tried to execute a static sequence of two behaviours that both succeed, you'd execute the first behaviour, then set current_child to the second behaviour, then execute the first behaviour, and set current_child to the second behaviour, then you'd be done because the main itertools iteration over the list of children would be done. However, after the change, with the sequence of two behaviours, you execute the first behaviour, set current_child to the second behaviour, then execute the second behaviour, try to set current_child to be the third behaviour, then hit the IndexError and pass, and still realize you were done because your itertools iteration is up.