### PR TITLE
[composites] selectors with memory

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -5,6 +5,7 @@ encoding//doc/examples/oneshot.py=utf-8
 encoding//doc/examples/parallel.py=utf-8
 encoding//doc/examples/pickup_where_you_left_off.py=utf-8
 encoding//doc/examples/selector.py=utf-8
+encoding//doc/examples/selector_with_memory.py=utf-8
 encoding//doc/examples/sequence.py=utf-8
 encoding//doc/examples/skeleton_behaviour.py=utf-8
 encoding//doc/examples/skeleton_tree.py=utf-8

--- a/doc/examples/selector_with_memory.py
+++ b/doc/examples/selector_with_memory.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import py_trees
+
+if __name__ == '__main__':
+    root = py_trees.composites.Selector("Selector With Memory", memory=True)
+    high = py_trees.behaviours.Success(name="High Priority")
+    med = py_trees.behaviours.Success(name="Med Priority")
+    low = py_trees.behaviours.Success(name="Low Priority")
+    root.add_children([high, med, low])
+    py_trees.display.render_dot_tree(root, py_trees.common.string_to_visibility_level("all"))

--- a/py_trees/behaviour.py
+++ b/py_trees/behaviour.py
@@ -377,16 +377,3 @@ class Behaviour(object):
             :class:`~py_trees.behaviour.Behaviour` or :obj:`None`: child behaviour, itself or :obj:`None` if its status is :data:`~py_trees.common.Status.INVALID`
         """
         return self if self.status != common.Status.INVALID else None
-
-    def verbose_info_string(self):
-        """
-        Override to provide a one line informative string about the behaviour. This
-        gets used in, e.g. dot graph rendering of the tree.
-
-        .. tip::
-           Use this sparingly. A good use case is for when the behaviour type
-           and class name isn't sufficient to inform the user about it's
-           mechanisms for controlling the flow of a tree tick (e.g. parallels
-           with policies).
-        """
-        return ""

--- a/py_trees/behaviours.py
+++ b/py_trees/behaviours.py
@@ -14,6 +14,7 @@ A library of fundamental behaviours for use.
 # Imports
 ##############################################################################
 
+import copy
 import functools
 import operator
 import typing
@@ -114,6 +115,37 @@ class Periodic(behaviour.Behaviour):
         else:
             self.feedback_message = "constant"
         return self.response
+
+
+class StatusSequence(behaviour.Behaviour):
+    """
+    Cycle through the specified sequence of states.
+
+    Args:
+        name: name of the behaviour
+        sequence: list of status values to cycle through
+        eventually: status to use eventually, None to re-cycle the sequence
+    """
+    def __init__(
+            self,
+            name: str,
+            sequence: typing.List[common.Status],
+            eventually: typing.Optional[common.Status]
+    ):
+        super(StatusSequence, self).__init__(name)
+        self.sequence = sequence
+        self.eventually = eventually
+        self.current_sequence = copy.copy(sequence)
+
+    def update(self):
+        if self.current_sequence:
+            status = self.current_sequence.pop(0)
+        elif self.eventually is not None:
+            status = self.eventually
+        else:
+            self.current_sequence = copy.copy(self.sequence)
+            status = self.current_sequence.pop(0)
+        return status
 
 
 class SuccessEveryN(behaviour.Behaviour):

--- a/py_trees/common.py
+++ b/py_trees/common.py
@@ -107,15 +107,6 @@ class ParallelPolicy(object):
             """
             super().__init__(synchronise=synchronise)
 
-        def __str__(self) -> str:
-            """
-            Human readable description.
-            """
-            description = "--" + self.__class__.__name__ + "("
-            description += console.lightning_bolt if self.synchronise else "-"
-            description += ")--"
-            return description
-
     class SuccessOnOne(Base):
         """
         Return :py:data:`~py_trees.common.Status.SUCCESS` so long as at least one child has :py:data:`~py_trees.common.Status.SUCCESS`
@@ -126,12 +117,6 @@ class ParallelPolicy(object):
             No configuration necessary for this policy.
             """
             super().__init__(synchronise=False)
-
-        def __str__(self) -> str:
-            """
-            Human readable description.
-            """
-            return "--" + self.__class__.__name__ + "--"
 
     class SuccessOnSelected(Base):
         """
@@ -150,17 +135,6 @@ class ParallelPolicy(object):
             """
             super().__init__(synchronise=synchronise)
             self.children = children
-
-        def __str__(self) -> str:
-            """
-            Human readable description.
-            """
-            description = "--" + self.__class__.__name__ + "("
-            description += console.lightning_bolt if self.synchronise else "-"
-            description += ","
-            description += "[" + ",".join([c.name for c in self.children]) + "]"
-            description += ")--"
-            return description
 
 
 class OneShotPolicy(enum.Enum):

--- a/py_trees/console.py
+++ b/py_trees/console.py
@@ -85,6 +85,7 @@ def define_symbol_or_fallback(original: str, fallback: str, encoding: str=sys.st
     return original
 
 
+circle = u'\u26ac'
 lightning_bolt = u'\u26A1'
 double_vertical_line = u'\u2016'
 check_mark = u'\u2713'
@@ -93,6 +94,7 @@ left_arrow = u'\u2190'  # u'\u2190'
 right_arrow = u'\u2192'
 left_right_arrow = u'\u2194'
 forbidden_circle = u'\u29B8'
+circled_m = u'\u24c2'
 
 ##############################################################################
 # Keypress
@@ -334,4 +336,5 @@ if __name__ == '__main__':
     print("multiplication_x: {}".format(multiplication_x))
     print("left_arrow: {}".format(left_arrow))
     print("right_arrow: {}".format(right_arrow))
+    print("circled_m: {}".format(circled_m))
     # print("has unicode: {}".format(has_unicode()))

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -58,7 +58,10 @@ def test_text_trees():
         success_until=10
     )
     low_priority = py_trees.behaviours.Running(name="Low Priority")
-    root.add_children([high_priority, low_priority])
+    selector_with_memory = py_trees.composites.Selector("Selector w/ Memory", memory=True)
+    success = py_trees.behaviours.Success("Success")
+    selector_with_memory.add_child(success)
+    root.add_children([high_priority, low_priority, selector_with_memory])
     tree = py_trees.trees.BehaviourTree(root)
     snapshot_visitor = py_trees.visitors.SnapshotVisitor()
     tree.visitors.append(snapshot_visitor)

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -65,29 +65,43 @@ def test_tick_running_with_no_memory():
     assert(child_2.status == py_trees.common.Status.INVALID)
 
 
-def test_tick_running_with_memory():
-    console.banner('Tick-Running with Memory')
+def test_with_memory_priority_handling():
+    # This test should check two things:
+    # 1) Skipped higher priorities are set to INVALID
+    # 2) On a running behaviour's eventual FAILURE, it proceeds to the next lower priority
+    console.banner('Tick-Running with Memory - Priority Handling')
     assert_banner()
     root = py_trees.composites.Selector(name="Selector w/ Memory", memory=True)
-    child_1 = py_trees.behaviours.Count(name="Fail Fast", fail_until=1, running_until=1, success_until=100)
-    child_2 = py_trees.behaviours.Running(name="Running")
-    root.add_children([child_1, child_2])
+    child_1 = py_trees.behaviours.Failure("Failure")
+    child_2 = py_trees.behaviours.StatusSequence(
+        name="Run-Fail",
+        sequence=[py_trees.common.Status.RUNNING,
+                  py_trees.common.Status.FAILURE],
+        eventually=None
+        )
+    child_3 = py_trees.behaviours.Success(name="Success")
+    root.add_children([child_1, child_2, child_3])
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("1::Selector Status", py_trees.common.Status.RUNNING, root.status)
     assert(root.status == py_trees.common.Status.RUNNING)
-    assert_details("2::Child 1 Status", py_trees.common.Status.FAILURE, child_1.status)
+    assert_details("1::Child 1 Status", py_trees.common.Status.FAILURE, child_1.status)
     assert(child_1.status == py_trees.common.Status.FAILURE)
-    assert_details("2::Child 2 Status", py_trees.common.Status.RUNNING, child_2.status)
+    assert_details("1::Child 2 Status", py_trees.common.Status.RUNNING, child_2.status)
     assert(child_2.status == py_trees.common.Status.RUNNING)
+    assert_details("1::Child 3 Status", py_trees.common.Status.INVALID, child_3.status)
+    assert(child_3.status == py_trees.common.Status.INVALID)
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
-    assert_details("2::Selector Status", py_trees.common.Status.RUNNING, root.status)
-    assert(root.status == py_trees.common.Status.RUNNING)
+    assert_details("1::Selector Status", py_trees.common.Status.SUCCESS, root.status)
+    assert(root.status == py_trees.common.Status.SUCCESS)
     assert_details("2::Child 1 Status", py_trees.common.Status.INVALID, child_1.status)
     assert(child_1.status == py_trees.common.Status.INVALID)
-    assert_details("2::Child 2 Status", py_trees.common.Status.RUNNING, child_2.status)
-    assert(child_2.status == py_trees.common.Status.RUNNING)
+    assert_details("2::Child 2 Status", py_trees.common.Status.FAILURE, child_2.status)
+    assert(child_2.status == py_trees.common.Status.FAILURE)
+    assert_details("2::Child 3 Status", py_trees.common.Status.SUCCESS, child_3.status)
+    assert(child_3.status == py_trees.common.Status.SUCCESS)
+
 
 ##############################################################################
 # Tests - Dynamic Insertion / Removal

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -40,6 +40,60 @@ def assert_details(text, expected, result):
 ##############################################################################
 
 
+def test_tick_running_with_no_memory():
+    console.banner('Tick-Running with No Memory')
+    assert_banner()
+    root = py_trees.composites.Selector(name="Selector w/o Memory", memory=False)
+    child_1 = py_trees.behaviours.Count(name="Fail Fast", fail_until=1, running_until=1, success_until=100)
+    child_2 = py_trees.behaviours.Running(name="Running")
+    root.add_children([child_1, child_2])
+    root.tick_once()
+    print(py_trees.display.unicode_tree(root, show_status=True))
+    assert_details("1::Selector Status", py_trees.common.Status.RUNNING, root.status)
+    assert(root.status == py_trees.common.Status.RUNNING)
+    assert_details("2::Child 1 Status", py_trees.common.Status.FAILURE, child_1.status)
+    assert(child_1.status == py_trees.common.Status.FAILURE)
+    assert_details("2::Child 2 Status", py_trees.common.Status.RUNNING, child_2.status)
+    assert(child_2.status == py_trees.common.Status.RUNNING)
+    root.tick_once()
+    print(py_trees.display.unicode_tree(root, show_status=True))
+    assert_details("2::Selector Status", py_trees.common.Status.SUCCESS, root.status)
+    assert(root.status == py_trees.common.Status.SUCCESS)
+    assert_details("2::Child 1 Status", py_trees.common.Status.SUCCESS, child_1.status)
+    assert(child_1.status == py_trees.common.Status.SUCCESS)
+    assert_details("2::Child 2 Status", py_trees.common.Status.INVALID, child_2.status)
+    assert(child_2.status == py_trees.common.Status.INVALID)
+
+
+def test_tick_running_with_memory():
+    console.banner('Tick-Running with Memory')
+    assert_banner()
+    root = py_trees.composites.Selector(name="Selector w/ Memory", memory=True)
+    child_1 = py_trees.behaviours.Count(name="Fail Fast", fail_until=1, running_until=1, success_until=100)
+    child_2 = py_trees.behaviours.Running(name="Running")
+    root.add_children([child_1, child_2])
+    root.tick_once()
+    print(py_trees.display.unicode_tree(root, show_status=True))
+    assert_details("1::Selector Status", py_trees.common.Status.RUNNING, root.status)
+    assert(root.status == py_trees.common.Status.RUNNING)
+    assert_details("2::Child 1 Status", py_trees.common.Status.FAILURE, child_1.status)
+    assert(child_1.status == py_trees.common.Status.FAILURE)
+    assert_details("2::Child 2 Status", py_trees.common.Status.RUNNING, child_2.status)
+    assert(child_2.status == py_trees.common.Status.RUNNING)
+    root.tick_once()
+    print(py_trees.display.unicode_tree(root, show_status=True))
+    assert_details("2::Selector Status", py_trees.common.Status.RUNNING, root.status)
+    assert(root.status == py_trees.common.Status.RUNNING)
+    assert_details("2::Child 1 Status", py_trees.common.Status.INVALID, child_1.status)
+    assert(child_1.status == py_trees.common.Status.INVALID)
+    assert_details("2::Child 2 Status", py_trees.common.Status.RUNNING, child_2.status)
+    assert(child_2.status == py_trees.common.Status.RUNNING)
+
+##############################################################################
+# Tests - Dynamic Insertion / Removal
+##############################################################################
+
+
 def test_tick_add_with_current_child():
     console.banner('Tick-Add with Current Child')
     assert_banner()


### PR DESCRIPTION
The Selector portion of handling #313.

**Priority Handling**

* Skips higher level priorities when a node is running
* Falls back to lower level priorities when a running node fails

![py_trees_memory_priority_handling](https://user-images.githubusercontent.com/687378/117040716-28a8da00-acd8-11eb-8cf3-9d2f414af1e8.png)

**Ascii Visualisation**

See above picture. Using curly brackets for selectors (later sequences) with memory. i.e. `(o)` vs `{o}`. 

**Dot Visualisation**

Prefixed with a circled M.

![selector_with_memory](https://user-images.githubusercontent.com/687378/117041053-8a694400-acd8-11eb-8beb-7917f1bd26b3.png)

**Viewer Support & Visualisation**

Adding information textually into the viewer, similar to parallel policies.

* https://github.com/splintered-reality/py_trees_ros/pull/173

![selector_with_memory_viewer](https://user-images.githubusercontent.com/687378/117052091-51839c00-ace5-11eb-8d0c-e63c0cce9876.png)

**Other**

* Eliminates `verbose_info_str`. Dropping anything in here, could ostensibly break the visualisation. Stick to supporting esoteric display mechanisms for the in-library composites, but don't try to reach beyond until/unless there is a better framework for handling that visualisation.
* Use indices for parallel policy strings so they don't get excessively long
* Bugfix unicode trees to actually use unicode symbols