### PR TITLE
Typing enhancements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/python:3.6.1
-      
+
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -39,7 +39,7 @@ jobs:
           paths:
             - ./venv
           key: setup-py-{{ checksum "setup.py" }}
-        
+
       # run tests!
       # this example uses Django's built-in test-runner
       # other common Python testing frameworks include pytest and nose
@@ -61,21 +61,20 @@ jobs:
           name: Static Analysers
           command: |
             . venv/bin/activate
-            mypy -p py_trees | tee mypy_output
+            mypy | tee mypy_output
 
       - store_artifacts:
           path: install_dependencies_output
           destination: install_dependencies_output
-            
+
       - store_artifacts:
           path: nosetests.html
           destination: nosetests.html
-          
+
       - store_artifacts:
           path: flake8_output
           destination: flake8_output
-            
+
       - store_artifacts:
           path: mypy_output
           destination: mypy_output
-          

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,13 +2,13 @@
 files = .
 ; syntax for multiple excludes
 exclude = (setup.py|doc)
+warn_return_any = True
+warn_unused_ignores = True
+warn_redundant_casts = True
 ; Consider enabling these for increased rigor
 ; warn_unused_configs = True
-; warn_return_any = True
 ; follow_imports = silent
 ; namespace_packages = True
-; warn_unused_ignores = True
-; warn_redundant_casts = True
 ; check_untyped_defs = True
 ; allow_untyped_defs = False
 ; explicit_package_bases = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,21 @@
+[mypy]
+files = .
+; syntax for multiple excludes
+exclude = (setup.py|doc)
+; Consider enabling these for increased rigor
+; warn_unused_configs = True
+; warn_return_any = True
+; follow_imports = silent
+; namespace_packages = True
+; warn_unused_ignores = True
+; warn_redundant_casts = True
+; check_untyped_defs = True
+; allow_untyped_defs = False
+; explicit_package_bases = True
+
+; These dependencies don't offer typing yet
+[mypy-nose.*]
+ignore_missing_imports = True
+
+[mypy-pydot.*]
+ignore_missing_imports = True

--- a/py_trees/behaviours.py
+++ b/py_trees/behaviours.py
@@ -346,7 +346,7 @@ class BlackboardToStatus(behaviour.Behaviour):
         self.logger.debug("%s.update()" % self.__class__.__name__)
         # raises a KeyError if the variable doesn't exist
         status = self.blackboard.get(self.variable_name)
-        if type(status) != common.Status:
+        if not isinstance(status, common.Status):
             raise TypeError(f"{self.variable_name} is not of type py_trees.common.Status")
         self.feedback_message = f"{self.variable_name}: {status}"
         return status

--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -825,7 +825,7 @@ class Client(object):
         Returns:
             The uuid.UUID object
         """
-        return super().__getattribute__("unique_identifier")
+        return typing.cast(uuid.UUID, super().__getattribute__("unique_identifier"))
 
     def __setattr__(self, name: str, value: typing.Any):
         """

--- a/py_trees/common.py
+++ b/py_trees/common.py
@@ -159,8 +159,10 @@ class ClearingPolicy(enum.IntEnum):
 # Blackboards
 ##############################################################################
 
+T_contra = typing.TypeVar('T_contra', contravariant=True)  # contravariant.
+V_contra = typing.TypeVar('V_contra', contravariant=True)  # contravariant.
 
-class ComparisonExpression(object):
+class ComparisonExpression(typing.Generic[T_contra, V_contra]):
     """
     Store the parameters for a univariate comparison operation
     (i.e. between a variable and a value).
@@ -177,7 +179,7 @@ class ComparisonExpression(object):
         self,
         variable: str,
         value: typing.Any,
-        operator: typing.Callable[[typing.Any, typing.Any], bool]
+        operator: typing.Callable[[T_contra, V_contra], bool]
     ):
         self.variable = variable
         self.value = value

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -69,6 +69,7 @@ from . import common
 
 
 class Composite(behaviour.Behaviour):
+
     """
     The parent class to all composite behaviours, i.e. those that
     have children.

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -293,7 +293,12 @@ class Selector(Composite):
         children ([:class:`~py_trees.behaviour.Behaviour`]): list of children to add
     """
 
-    def __init__(self, name="Selector", memory=False, children=None):
+    def __init__(
+        self,
+        name: str="Selector",
+        memory: bool=False,
+        children: typing.List[behaviour.Behaviour]=None
+    ):
         super(Selector, self).__init__(name, children)
         self.memory = memory
 

--- a/py_trees/meta.py
+++ b/py_trees/meta.py
@@ -16,6 +16,7 @@ themselves.
 # Imports
 ##############################################################################
 
+from typing import Type
 from . import behaviour
 from . import common
 
@@ -24,7 +25,7 @@ from . import common
 ##############################################################################
 
 
-def create_behaviour_from_function(func):
+def create_behaviour_from_function(func) -> Type[behaviour.Behaviour]:
     """
     Create a behaviour from the specified function, dropping it in for
     the Behaviour :meth:`~py_trees.behaviour.Behaviour.update` method.

--- a/py_trees/trees.py
+++ b/py_trees/trees.py
@@ -117,7 +117,9 @@ def setup(root: behaviour.Behaviour,
             timer.start()
             visited_setup()
         finally:
+            print("Stopping setup timer")
             timer.cancel()  # this only works if the timer is still waiting
+            timer.join()
             signal.signal(_SIGNAL, original_signal_handler)
 
 ##############################################################################

--- a/tests/test_parallels.py
+++ b/tests/test_parallels.py
@@ -358,17 +358,17 @@ def test_parallel_no_synchronisation():
         print(counter)
         if counter % 2 == 0:
             print("success_every_two.status == py_trees.common.Status.SUCCESS")
-            assert(success_every_two.status == py_trees.common.Status.SUCCESS)
+            assert success_every_two.status == py_trees.common.Status.SUCCESS
         elif counter % 3 == 0:
             print("success_every_three.status == py_trees.common.Status.SUCCESS")
-            assert(success_every_three.status == py_trees.common.Status.SUCCESS)
+            assert success_every_three.status == py_trees.common.Status.SUCCESS
         else:
             print("success_every_two.status == py_trees.common.Status.RUNNING")
-            assert(success_every_two.status == py_trees.common.Status.RUNNING)
+            assert success_every_two.status == py_trees.common.Status.RUNNING
             print("success_every_three.status == py_trees.common.Status.RUNNING")
-            assert(success_every_three.status == py_trees.common.Status.RUNNING)
+            assert success_every_three.status == py_trees.common.Status.RUNNING
         print("root.status == py_trees.common.Status.RUNNING")
-        assert(root.status == py_trees.common.Status.RUNNING, "{}, {}".format(root.status, counter))
+        assert root.status == py_trees.common.Status.RUNNING, "{}, {}".format(root.status, counter)
 
     snapshot_visitor.initialise()
     py_trees.tests.tick_tree(
@@ -376,11 +376,11 @@ def test_parallel_no_synchronisation():
         print_snapshot=True
     )
     print("success_every_two.status == py_trees.common.Status.SUCCESS")
-    assert(success_every_two.status == py_trees.common.Status.SUCCESS)
+    assert success_every_two.status == py_trees.common.Status.SUCCESS
     print("success_every_three.status == py_trees.common.Status.SUCCESS")
-    assert(success_every_three.status == py_trees.common.Status.SUCCESS)
+    assert success_every_three.status == py_trees.common.Status.SUCCESS
     print("root.status == py_trees.common.Status.SUCCESS")
-    assert(root.status == py_trees.common.Status.SUCCESS)
+    assert root.status == py_trees.common.Status.SUCCESS
 
 
 def test_add_tick_remove_with_current_child():
@@ -396,7 +396,7 @@ def test_add_tick_remove_with_current_child():
     root.remove_child(child)
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
     root.add_child(child)
     root.tick_once()
@@ -404,7 +404,7 @@ def test_add_tick_remove_with_current_child():
     root.remove_all_children()
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
     replacement = py_trees.behaviours.Success(name="Replacement")
     root.add_child(child)
@@ -413,7 +413,7 @@ def test_add_tick_remove_with_current_child():
     root.replace_child(child=child, replacement=replacement)
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
     root.remove_all_children()
     root.add_child(child)
@@ -422,7 +422,7 @@ def test_add_tick_remove_with_current_child():
     root.remove_child_by_id(child_id=child.id)
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
 
 def test_tick_add_with_current_child():
@@ -435,7 +435,7 @@ def test_tick_add_with_current_child():
     child = py_trees.behaviours.Failure(name="Failure")
     root.add_child(child)
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
 
 def test_add_tick_add_with_current_child():
@@ -450,11 +450,11 @@ def test_add_tick_add_with_current_child():
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", run1.name, root.current_child.name)
-    assert(root.current_child.name == run1.name)
+    assert root.current_child.name == run1.name
     root.add_child(run2)
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", run1.name, root.current_child.name)
-    assert(root.current_child.name == run1.name)
+    assert root.current_child.name == run1.name
 
 
 def test_add_tick_insert_with_current_child():
@@ -469,8 +469,8 @@ def test_add_tick_insert_with_current_child():
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", run1.name, root.current_child.name)
-    assert(root.current_child.name == run1.name)
+    assert root.current_child.name == run1.name
     root.insert_child(run2, index=0)
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", run1.name, root.current_child.name)
-    assert(root.current_child.name == run1.name)
+    assert root.current_child.name == run1.name

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -570,7 +570,7 @@ def test_tree_setup():
     assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
-    print(console.cyan + "Short timeout: " + console.yellow + "No Visitor" + console.reset)
+    print(console.cyan + "Long timeout: " + console.yellow + "No Visitor" + console.reset)
     try:
         tree.setup(timeout=4 * duration)
     except RuntimeError:
@@ -579,7 +579,7 @@ def test_tree_setup():
     assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
-    print(console.cyan + "Long Timeout: " + console.yellow + "With Visitor" + console.reset)
+    print(console.cyan + "Short Timeout: " + console.yellow + "With Visitor" + console.reset)
     visitor = SetupVisitor()
     with nose.tools.assert_raises(RuntimeError) as context:
         tree.setup(timeout=2 * duration, visitor=visitor)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -510,7 +510,7 @@ def test_failed_tree():
     tree.tick()
     print("\n--------- Assertions ---------\n")
     print("root.tip().name == Failure 3")
-    assert(root.tip().name == "Failure 3")
+    assert root.tip().name == "Failure 3"
 
     # TODO failed sequence tree
 
@@ -522,7 +522,7 @@ def test_tree_errors():
     with nose.tools.assert_raises(TypeError) as context:
         unused_tree = py_trees.trees.BehaviourTree(root)
         print("TypeError has message with substring 'must be an instance of'")
-        assert("must be an instance of" in str(context.exception))
+        assert "must be an instance of" in str(context.exception)
 
     root = py_trees.behaviours.Success()
     print("__init__ raises a 'RuntimeError' because we try to prune the root node")
@@ -530,7 +530,7 @@ def test_tree_errors():
         tree = py_trees.trees.BehaviourTree(root)
         tree.prune_subtree(root.id)
         print("RuntimeError has message with substring 'prune'")
-        assert("prune" in str(context.exception))
+        assert "prune" in str(context.exception)
 
     root = py_trees.behaviours.Success()
     new_subtree = py_trees.behaviours.Success()
@@ -539,7 +539,7 @@ def test_tree_errors():
         tree = py_trees.trees.BehaviourTree(root)
         tree.replace_subtree(root.id, new_subtree)
         print("RuntimeError has message with substring 'replace'")
-        assert("replace" in str(context.exception))
+        assert "replace" in str(context.exception)
 
     root = py_trees.behaviours.Success()
     new_subtree = py_trees.behaviours.Success()
@@ -548,7 +548,7 @@ def test_tree_errors():
         tree = py_trees.trees.BehaviourTree(root)
         tree.insert_subtree(child=new_subtree, unique_id=root.id, index=0)
         print("TypeError has message with substring 'Composite'")
-        assert("Composite" in str(context.exception))
+        assert "Composite" in str(context.exception)
 
 
 def test_tree_setup():
@@ -567,7 +567,7 @@ def test_tree_setup():
     print("RuntimeError has message with substring 'timed out'")
     assert("timed out" in str(context.exception))
     active_threads = threading.active_count()
-    assert(active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads))
+    assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
     print(console.cyan + "Short timeout: " + console.yellow + "No Visitor" + console.reset)
@@ -576,7 +576,7 @@ def test_tree_setup():
     except RuntimeError:
         assert False, "should not have timed out"
     active_threads = threading.active_count()
-    assert(active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads))
+    assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
     print(console.cyan + "Long Timeout: " + console.yellow + "With Visitor" + console.reset)
@@ -586,7 +586,7 @@ def test_tree_setup():
     print("RuntimeError has message with substring 'timed out'")
     assert("timed out" in str(context.exception))
     active_threads = threading.active_count()
-    assert(active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads))
+    assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
     print(console.cyan + "Long timeout: " + console.yellow + "With Visitor" + console.reset)
@@ -596,7 +596,7 @@ def test_tree_setup():
     except RuntimeError:
         assert False, "should not have timed out"
     active_threads = threading.active_count()
-    assert(active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads))
+    assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
     print(console.cyan + "No timeout: " + console.yellow + "No Visitor" + console.reset)
@@ -606,7 +606,7 @@ def test_tree_setup():
     except RuntimeError:
         assert False, "should not have timed out"
     active_threads = threading.active_count()
-    assert(active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads))
+    assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
 
 def test_pre_post_tick_activity_sequence():
@@ -647,14 +647,14 @@ def test_pre_post_tick_activity_sequence():
         "one_shot_post_tick_handler"
     ]
     print("")
-    assert(len(breadcrumbs) == len(expected_breadcrumbs))
+    assert len(breadcrumbs) == len(expected_breadcrumbs)
     for expected, actual in zip(expected_breadcrumbs, breadcrumbs):
         print(
             console.green + "Breadcrumb..................." +
             console.cyan + "{} ".format(expected) +
             console.yellow + "[{}]".format(actual)
         )
-        assert(expected == actual)
+        assert expected == actual
 
 
 def test_unicode_tree_debug():


### PR DESCRIPTION
This PR makes a few typing-related changes:

* enables typing "approximately project wide" - py_trees and tests are checked, setup.py and doc/ is not
* Adds Generics to ComparisonExpression (https://github.com/splintered-reality/py_trees/issues/336)
* Adds a return type to create_behaviour_from_function() (https://github.com/splintered-reality/py_trees/issues/334)
* Removes parenthesis from some asserts - using parens around asserts is bad practice, especially when you want to add a description to the assert. This became apparent when I enabled mypy on tests/. Note this revealed a failing test which I don't know how to address. See https://stackoverflow.com/a/3112178/1017787 for more details.

I also experimented with addressing #337 and #335, bit found the solutions were not as obvious.