### PR TITLE
Make type checking even more rigorous

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/python:3.6.1
-      
+
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -39,7 +39,7 @@ jobs:
           paths:
             - ./venv
           key: setup-py-{{ checksum "setup.py" }}
-        
+
       # run tests!
       # this example uses Django's built-in test-runner
       # other common Python testing frameworks include pytest and nose
@@ -61,21 +61,20 @@ jobs:
           name: Static Analysers
           command: |
             . venv/bin/activate
-            mypy -p py_trees | tee mypy_output
+            mypy | tee mypy_output
 
       - store_artifacts:
           path: install_dependencies_output
           destination: install_dependencies_output
-            
+
       - store_artifacts:
           path: nosetests.html
           destination: nosetests.html
-          
+
       - store_artifacts:
           path: flake8_output
           destination: flake8_output
-            
+
       - store_artifacts:
           path: mypy_output
           destination: mypy_output
-          

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,13 +2,13 @@
 files = .
 ; syntax for multiple excludes
 exclude = (setup.py|doc)
+warn_return_any = True
+warn_unused_ignores = True
+warn_redundant_casts = True
 ; Consider enabling these for increased rigor
 ; warn_unused_configs = True
-; warn_return_any = True
 ; follow_imports = silent
 ; namespace_packages = True
-; warn_unused_ignores = True
-; warn_redundant_casts = True
 ; check_untyped_defs = True
 ; allow_untyped_defs = False
 ; explicit_package_bases = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,11 +5,11 @@ exclude = (setup.py|doc)
 warn_return_any = True
 warn_unused_ignores = True
 warn_redundant_casts = True
+check_untyped_defs = True
 ; Consider enabling these for increased rigor
 ; warn_unused_configs = True
 ; follow_imports = silent
 ; namespace_packages = True
-; check_untyped_defs = True
 ; allow_untyped_defs = False
 ; explicit_package_bases = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,21 @@
+[mypy]
+files = .
+; syntax for multiple excludes
+exclude = (setup.py|doc)
+; Consider enabling these for increased rigor
+; warn_unused_configs = True
+; warn_return_any = True
+; follow_imports = silent
+; namespace_packages = True
+; warn_unused_ignores = True
+; warn_redundant_casts = True
+; check_untyped_defs = True
+; allow_untyped_defs = False
+; explicit_package_bases = True
+
+; These dependencies don't offer typing yet
+[mypy-nose.*]
+ignore_missing_imports = True
+
+[mypy-pydot.*]
+ignore_missing_imports = True

--- a/py_trees/behaviours.py
+++ b/py_trees/behaviours.py
@@ -346,7 +346,7 @@ class BlackboardToStatus(behaviour.Behaviour):
         self.logger.debug("%s.update()" % self.__class__.__name__)
         # raises a KeyError if the variable doesn't exist
         status = self.blackboard.get(self.variable_name)
-        if type(status) != common.Status:
+        if not isinstance(status, common.Status):
             raise TypeError(f"{self.variable_name} is not of type py_trees.common.Status")
         self.feedback_message = f"{self.variable_name}: {status}"
         return status

--- a/py_trees/behaviours.py
+++ b/py_trees/behaviours.py
@@ -564,7 +564,7 @@ class CheckBlackboardVariableValue(behaviour.Behaviour):
                 try:
                     value = operator.attrgetter(self.key_attributes)(value)
                 except AttributeError:
-                    self.feedback_message = 'blackboard key-value pair exists, but the value does not have the requested nested attributes [{}]'.format(self.variable_name)
+                    self.feedback_message = 'blackboard key-value pair exists, but the value does not have the requested nested attributes [{}]'.format(self.check.variable)
                     return common.Status.FAILURE
         except KeyError:
             self.feedback_message = "key '{}' does not yet exist on the blackboard".format(self.check.variable)

--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -1124,11 +1124,11 @@ class Client(object):
         s += console.white + indent + "Client Data" + console.reset + "\n"
         keys = ["name", "namespace", "unique_identifier", "read", "write", "exclusive"]
         s += self._stringify_key_value_pairs(keys, self.__dict__, 2 * indent)
-        keys = {k for k, v in self.remappings.items() if k != v}
-        if keys:
+        key_set = {k for k, v in self.remappings.items() if k != v}
+        if key_set:
             s += console.white + indent + "Remappings" + console.reset + "\n"
             s += self._stringify_key_value_pairs(
-                keys=keys,
+                keys=key_set,
                 key_value_dict=self.remappings,
                 indent=2 * indent,
                 separator=console.right_arrow

--- a/py_trees/blackboard.py
+++ b/py_trees/blackboard.py
@@ -825,7 +825,7 @@ class Client(object):
         Returns:
             The uuid.UUID object
         """
-        return super().__getattribute__("unique_identifier")
+        return typing.cast(uuid.UUID, super().__getattribute__("unique_identifier"))
 
     def __setattr__(self, name: str, value: typing.Any):
         """

--- a/py_trees/common.py
+++ b/py_trees/common.py
@@ -144,17 +144,6 @@ class OneShotPolicy(enum.Enum):
     """Permits the oneshot to keep trying until it's first success."""
 
 
-class ClearingPolicy(enum.IntEnum):
-    """
-    Policy rules for behaviours to dictate when data should be cleared/reset.
-    """
-    ON_INITIALISE = 1
-    """Clear when entering the :py:meth:`~py_trees.behaviour.Behaviour.initialise` method."""
-    ON_SUCCESS = 2
-    """Clear when returning :py:data:`~py_trees.common.Status.SUCCESS`."""
-    NEVER = 3
-    """Never clear the data"""
-
 ##############################################################################
 # Blackboards
 ##############################################################################

--- a/py_trees/common.py
+++ b/py_trees/common.py
@@ -159,8 +159,10 @@ class ClearingPolicy(enum.IntEnum):
 # Blackboards
 ##############################################################################
 
+T_contra = typing.TypeVar('T_contra', contravariant=True)  # contravariant.
+V_contra = typing.TypeVar('V_contra', contravariant=True)  # contravariant.
 
-class ComparisonExpression(object):
+class ComparisonExpression(typing.Generic[T_contra, V_contra]):
     """
     Store the parameters for a univariate comparison operation
     (i.e. between a variable and a value).
@@ -177,7 +179,7 @@ class ComparisonExpression(object):
         self,
         variable: str,
         value: typing.Any,
-        operator: typing.Callable[[typing.Any, typing.Any], bool]
+        operator: typing.Callable[[T_contra, V_contra], bool]
     ):
         self.variable = variable
         self.value = value

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -69,6 +69,7 @@ from . import common
 
 
 class Composite(behaviour.Behaviour):
+
     """
     The parent class to all composite behaviours, i.e. those that
     have children.

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -69,6 +69,7 @@ from . import common
 
 
 class Composite(behaviour.Behaviour):
+    current_child: typing.Optional[behaviour.Behaviour]
 
     """
     The parent class to all composite behaviours, i.e. those that
@@ -338,6 +339,7 @@ class Selector(Composite):
 
         # starting point
         if self.memory:
+            assert self.current_child is not None
             index = self.children.index(self.current_child)
             # clear out preceding status' - not actually necessary but helps
             # visualise the case of memory vs no memory
@@ -447,6 +449,7 @@ class Sequence(Composite):
             # user specific initialisation
             self.initialise()
         else:  # self.memory is True and status is RUNNING
+            assert self.current_child is not None
             index = self.children.index(self.current_child)
 
         # customised work
@@ -604,7 +607,7 @@ class Parallel(Composite):
                 if successful:
                     new_status = common.Status.SUCCESS
                     self.current_child = successful[-1]
-            elif type(self.policy) is common.ParallelPolicy.SuccessOnSelected:
+            elif isinstance(self.policy, common.ParallelPolicy.SuccessOnSelected):
                 if all([c.status == common.Status.SUCCESS for c in self.policy.children]):
                     new_status = common.Status.SUCCESS
                     self.current_child = self.policy.children[-1]
@@ -645,7 +648,7 @@ class Parallel(Composite):
         Raises:
             RuntimeError: if policy configuration was invalid
         """
-        if type(self.policy) is common.ParallelPolicy.SuccessOnSelected:
+        if isinstance(self.policy, common.ParallelPolicy.SuccessOnSelected):
             if not self.policy.children:
                 error_message = ("policy SuccessOnSelected requires a non-empty "
                                  "selection of children [{}]".format(self.name))

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -293,7 +293,12 @@ class Selector(Composite):
         children ([:class:`~py_trees.behaviour.Behaviour`]): list of children to add
     """
 
-    def __init__(self, name="Selector", memory=False, children=None):
+    def __init__(
+        self,
+        name: str="Selector",
+        memory: bool=False,
+        children: typing.List[behaviour.Behaviour]=None
+    ):
         super(Selector, self).__init__(name, children)
         self.memory = memory
 

--- a/py_trees/decorators.py
+++ b/py_trees/decorators.py
@@ -81,7 +81,7 @@ import inspect
 import time
 import typing
 
-from typing import Callable, List, Set, Union  # noqa
+from typing import Callable, List, Optional, Set, Union  # noqa
 
 from . import behaviour
 from . import blackboard
@@ -374,7 +374,7 @@ class Timeout(Decorator):
         """
         super(Timeout, self).__init__(name=name, child=child)
         self.duration = duration
-        self.finish_time = None
+        self.finish_time: Optional[float] = None
 
     def initialise(self):
         """
@@ -389,6 +389,7 @@ class Timeout(Decorator):
         if the timeout is exceeded.
         """
         current_time = time.monotonic()
+        assert self.finish_time is not None
         if self.decorated.status == common.Status.RUNNING and current_time > self.finish_time:
             self.feedback_message = "timed out"
             self.logger.debug("{}.update() {}".format(self.__class__.__name__, self.feedback_message))

--- a/py_trees/meta.py
+++ b/py_trees/meta.py
@@ -16,6 +16,7 @@ themselves.
 # Imports
 ##############################################################################
 
+from typing import Type
 from . import behaviour
 from . import common
 
@@ -24,7 +25,7 @@ from . import common
 ##############################################################################
 
 
-def create_behaviour_from_function(func):
+def create_behaviour_from_function(func) -> Type[behaviour.Behaviour]:
     """
     Create a behaviour from the specified function, dropping it in for
     the Behaviour :meth:`~py_trees.behaviour.Behaviour.update` method.

--- a/py_trees/timers.py
+++ b/py_trees/timers.py
@@ -77,6 +77,7 @@ class Timer(behaviour.Behaviour):
         """
         self.logger.debug("%s.update()" % self.__class__.__name__)
         current_time = time.time()
+        assert self.finish_time is not None
         if current_time > self.finish_time:
             self.feedback_message = "timer ran out [{0}]".format(self.duration)
             return common.Status.SUCCESS

--- a/py_trees/trees.py
+++ b/py_trees/trees.py
@@ -117,7 +117,9 @@ def setup(root: behaviour.Behaviour,
             timer.start()
             visited_setup()
         finally:
+            print("Stopping setup timer")
             timer.cancel()  # this only works if the timer is still waiting
+            timer.join()
             signal.signal(_SIGNAL, original_signal_handler)
 
 ##############################################################################

--- a/py_trees/trees.py
+++ b/py_trees/trees.py
@@ -43,6 +43,7 @@ CONTINUOUS_TICK_TOCK = -1
 # Methods
 ##############################################################################
 
+current_behaviour_name: str = ""
 
 def setup(root: behaviour.Behaviour,
           timeout: typing.Union[float, common.Duration]=common.Duration.INFINITE,
@@ -78,7 +79,6 @@ def setup(root: behaviour.Behaviour,
         # it will work in most situations. If a windows user is running into
         # problems, work with them to resolve it.
         _SIGNAL = signal.SIGINT
-    current_behaviour_name = None
 
     def on_timer_timed_out():
         os.kill(os.getpid(), _SIGNAL)

--- a/py_trees/visitors.py
+++ b/py_trees/visitors.py
@@ -169,6 +169,7 @@ class DisplaySnapshotVisitor(SnapshotVisitor):
         self.root = None
         super().initialise()
         if self.display_activity_stream:
+            assert blackboard.Blackboard.activity_stream is not None
             blackboard.Blackboard.activity_stream.clear()
 
     def run(self, behaviour):

--- a/tests/benchmark_blackboard.py
+++ b/tests/benchmark_blackboard.py
@@ -9,6 +9,7 @@
 ##############################################################################
 
 import time
+from typing import Any, Dict
 
 import py_trees
 import py_trees.console as console
@@ -115,7 +116,7 @@ def benchmark_read():
                     py_trees.blackboard.Blackboard.set("/colander_{}".format(i), i)
                     py_trees.blackboard.Blackboard.set("/parameters/colander_{}".format(i), i)
             relative_names = {}
-            absolute_names = {"Root": {}, "Namespaced": {}}
+            absolute_names: Dict[str, Dict[int, str]] = {"Root": {}, "Namespaced": {}}
             for i in range(0, 1000):
                 relative_names[i] = "colander_{}".format(i)
                 absolute_names["Root"][i] = "/colander_{}".format(i)
@@ -164,7 +165,7 @@ def benchmark_write():
                             access=py_trees.common.Access.WRITE,
                         )
             relative_names = {}
-            absolute_names = {"Root": {}, "Namespaced": {}}
+            absolute_names: Dict[str, Dict[int, str]] = {"Root": {}, "Namespaced": {}}
             for i in range(0, 1000):
                 relative_names[i] = str(i)
                 absolute_names["Root"][i] = "/{}".format(str(i))

--- a/tests/test_blackboard.py
+++ b/tests/test_blackboard.py
@@ -8,12 +8,15 @@
 # Imports
 ##############################################################################
 
+from contextlib import AbstractContextManager
+
 import nose
 
 import py_trees
 import py_trees.console as console
 
 from py_trees.blackboard import Blackboard
+
 
 ##############################################################################
 # Helpers
@@ -28,7 +31,7 @@ class Motley(object):
         self.nested = "nested"
 
 
-class create_blackboards(object):
+class create_blackboards(AbstractContextManager):
 
     def __enter__(self):
         self.foo = create_blackboard_foo()
@@ -41,7 +44,7 @@ class create_blackboards(object):
         self.bar.unregister(clear=True)
 
 
-class create_namespaced_blackboards(object):
+class create_namespaced_blackboards(AbstractContextManager):
 
     def __enter__(self):
         self.namespace = "/woohoo"
@@ -106,7 +109,7 @@ def test_bad_name_exception():
     console.banner("Bad Name Exception")
     with nose.tools.assert_raises_regexp(TypeError, "str"):
         print("Expecting a TypeError with substring 'str'")
-        unused_blackboard = py_trees.blackboard.Client(name=5)
+        unused_blackboard = py_trees.blackboard.Client(name=5)  # type: ignore
 
 
 def test_unregister_keys_with_clear():
@@ -337,6 +340,7 @@ def test_activity_stream():
         py_trees.blackboard.ActivityType.NO_OVERWRITE,
         py_trees.blackboard.ActivityType.UNSET,
     ]
+    assert Blackboard.activity_stream is not None
     for item, expected in zip(Blackboard.activity_stream.data, expected_types):
         assert(item.activity_type == expected.value)
     blackboard.unregister(clear=True)

--- a/tests/test_blackboard_behaviours.py
+++ b/tests/test_blackboard_behaviours.py
@@ -8,6 +8,7 @@
 # Imports
 ##############################################################################
 
+from typing import Callable, cast
 import nose
 import operator
 
@@ -569,7 +570,7 @@ def test_check_variable_values():
         blackboard.b = data['b']
         blackboard.c = data['c']
         blackboard.d = data['d']
-        b.operator = data['operator']
+        b.operator = cast(Callable[[bool, bool], bool], data['operator'])
         b.tick_once()
         assert_details(
             text="[a:{}|b:{}|c:{}|d:{}]{} - {}".format(blackboard.a, blackboard.b, blackboard.c, blackboard.d, b.feedback_message, data['text']),

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -9,6 +9,7 @@
 ##############################################################################
 
 import functools
+from typing import Any, Dict, Tuple
 import py_trees
 import py_trees.console as console
 import py_trees.display as display
@@ -21,6 +22,8 @@ import xml.etree.ElementTree
 
 def test_symbols():
     console.banner("Symbols")
+
+    symbol_groups: Tuple[Dict[object, Any], ...]
     # This test has no assertions, except from the human eye. When it fails,
     # ticks and crosses fail and must be inspected by the human eye
     if console.has_unicode():

--- a/tests/test_parallels.py
+++ b/tests/test_parallels.py
@@ -8,6 +8,7 @@
 # Imports
 ##############################################################################
 import itertools
+from typing import Any
 import nose.tools
 import py_trees
 import py_trees.console as console
@@ -28,7 +29,7 @@ def assert_banner():
     print(console.green + "----- Asserts -----" + console.reset)
 
 
-def assert_details(text, expected, result):
+def assert_details(text: str, expected: Any, result: Any):
     print(console.green + text +
           "." * (70 - len(text)) +
           console.cyan + "{}".format(expected) +
@@ -449,10 +450,12 @@ def test_add_tick_add_with_current_child():
     root.add_child(run1)
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert root.current_child.name == run1.name
     root.add_child(run2)
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert root.current_child.name == run1.name
 
@@ -468,9 +471,11 @@ def test_add_tick_insert_with_current_child():
     root.add_child(run1)
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert root.current_child.name == run1.name
     root.insert_child(run2, index=0)
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert root.current_child.name == run1.name

--- a/tests/test_parallels.py
+++ b/tests/test_parallels.py
@@ -358,17 +358,17 @@ def test_parallel_no_synchronisation():
         print(counter)
         if counter % 2 == 0:
             print("success_every_two.status == py_trees.common.Status.SUCCESS")
-            assert(success_every_two.status == py_trees.common.Status.SUCCESS)
+            assert success_every_two.status == py_trees.common.Status.SUCCESS
         elif counter % 3 == 0:
             print("success_every_three.status == py_trees.common.Status.SUCCESS")
-            assert(success_every_three.status == py_trees.common.Status.SUCCESS)
+            assert success_every_three.status == py_trees.common.Status.SUCCESS
         else:
             print("success_every_two.status == py_trees.common.Status.RUNNING")
-            assert(success_every_two.status == py_trees.common.Status.RUNNING)
+            assert success_every_two.status == py_trees.common.Status.RUNNING
             print("success_every_three.status == py_trees.common.Status.RUNNING")
-            assert(success_every_three.status == py_trees.common.Status.RUNNING)
+            assert success_every_three.status == py_trees.common.Status.RUNNING
         print("root.status == py_trees.common.Status.RUNNING")
-        assert(root.status == py_trees.common.Status.RUNNING, "{}, {}".format(root.status, counter))
+        assert root.status == py_trees.common.Status.RUNNING, "{}, {}".format(root.status, counter)
 
     snapshot_visitor.initialise()
     py_trees.tests.tick_tree(
@@ -376,11 +376,11 @@ def test_parallel_no_synchronisation():
         print_snapshot=True
     )
     print("success_every_two.status == py_trees.common.Status.SUCCESS")
-    assert(success_every_two.status == py_trees.common.Status.SUCCESS)
+    assert success_every_two.status == py_trees.common.Status.SUCCESS
     print("success_every_three.status == py_trees.common.Status.SUCCESS")
-    assert(success_every_three.status == py_trees.common.Status.SUCCESS)
+    assert success_every_three.status == py_trees.common.Status.SUCCESS
     print("root.status == py_trees.common.Status.SUCCESS")
-    assert(root.status == py_trees.common.Status.SUCCESS)
+    assert root.status == py_trees.common.Status.SUCCESS
 
 
 def test_add_tick_remove_with_current_child():
@@ -396,7 +396,7 @@ def test_add_tick_remove_with_current_child():
     root.remove_child(child)
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
     root.add_child(child)
     root.tick_once()
@@ -404,7 +404,7 @@ def test_add_tick_remove_with_current_child():
     root.remove_all_children()
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
     replacement = py_trees.behaviours.Success(name="Replacement")
     root.add_child(child)
@@ -413,7 +413,7 @@ def test_add_tick_remove_with_current_child():
     root.replace_child(child=child, replacement=replacement)
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
     root.remove_all_children()
     root.add_child(child)
@@ -422,7 +422,7 @@ def test_add_tick_remove_with_current_child():
     root.remove_child_by_id(child_id=child.id)
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
 
 def test_tick_add_with_current_child():
@@ -435,7 +435,7 @@ def test_tick_add_with_current_child():
     child = py_trees.behaviours.Failure(name="Failure")
     root.add_child(child)
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
 
 def test_add_tick_add_with_current_child():
@@ -450,11 +450,11 @@ def test_add_tick_add_with_current_child():
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", run1.name, root.current_child.name)
-    assert(root.current_child.name == run1.name)
+    assert root.current_child.name == run1.name
     root.add_child(run2)
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", run1.name, root.current_child.name)
-    assert(root.current_child.name == run1.name)
+    assert root.current_child.name == run1.name
 
 
 def test_add_tick_insert_with_current_child():
@@ -469,8 +469,8 @@ def test_add_tick_insert_with_current_child():
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", run1.name, root.current_child.name)
-    assert(root.current_child.name == run1.name)
+    assert root.current_child.name == run1.name
     root.insert_child(run2, index=0)
     print(py_trees.display.unicode_tree(root, show_status=True))
     assert_details("Current Child", run1.name, root.current_child.name)
-    assert(root.current_child.name == run1.name)
+    assert root.current_child.name == run1.name

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -8,6 +8,7 @@
 # Imports
 ##############################################################################
 import itertools
+from typing import Any
 import nose.tools
 import py_trees
 import py_trees.console as console
@@ -28,7 +29,7 @@ def assert_banner():
     print(console.green + "----- Asserts -----" + console.reset)
 
 
-def assert_details(text, expected, result):
+def assert_details(text: str, expected: Any, result: Any):
     print(console.green + text +
           "." * (70 - len(text)) +
           console.cyan + "{}".format(expected) +
@@ -130,10 +131,12 @@ def test_add_tick_add_with_current_child():
     root.add_child(run1)
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert(root.current_child.name == run1.name)
     root.add_child(run2)
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert(root.current_child.name == run1.name)
 
@@ -147,10 +150,12 @@ def test_add_tick_insert_with_current_child():
     root.add_child(run1)
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert(root.current_child.name == run1.name)
     root.insert_child(run2, index=0)
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert(root.current_child.name == run1.name)
 

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -222,18 +222,16 @@ def test_add_tick_remove_with_current_child():
     print(py_trees.display.unicode_tree(root, show_status=True))
     root.remove_child(child)
     print(py_trees.display.unicode_tree(root, show_status=True))
-    assert root.current_child is not None
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
     root.add_child(child)
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
     root.remove_all_children()
     print(py_trees.display.unicode_tree(root, show_status=True))
-    assert root.current_child is not None
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
     replacement = py_trees.behaviours.Success(name="Replacement")
     root.add_child(child)
@@ -241,9 +239,8 @@ def test_add_tick_remove_with_current_child():
     print(py_trees.display.unicode_tree(root, show_status=True))
     root.replace_child(child=child, replacement=replacement)
     print(py_trees.display.unicode_tree(root, show_status=True))
-    assert root.current_child is not None
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None
 
     root.remove_all_children()
     root.add_child(child)
@@ -251,6 +248,5 @@ def test_add_tick_remove_with_current_child():
     print(py_trees.display.unicode_tree(root, show_status=True))
     root.remove_child_by_id(child_id=child.id)
     print(py_trees.display.unicode_tree(root, show_status=True))
-    assert root.current_child is not None
     assert_details("Current Child", None, root.current_child)
-    assert(root.current_child is None)
+    assert root.current_child is None

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -8,6 +8,7 @@
 # Imports
 ##############################################################################
 
+from typing import Any
 import py_trees
 import py_trees.console as console
 
@@ -27,12 +28,13 @@ def assert_banner():
     print(console.green + "----- Asserts -----" + console.reset)
 
 
-def assert_details(text, expected, result):
+def assert_details(text: str, expected: Any, result: Any):
     print(console.green + text +
           "." * (70 - len(text)) +
           console.cyan + "{}".format(expected) +
           console.yellow + " [{}]".format(result) +
           console.reset)
+
 
 ##############################################################################
 # Tests
@@ -130,6 +132,7 @@ def test_static_sequence_successes():
 
     root.tick_once()
 
+    assert root.current_child is not None
     assert_details("Current Child", success4.name, root.current_child.name)
     assert root.tip().name == success4.name, 'should execute all 4 nodes of this Sequence'
 
@@ -153,6 +156,7 @@ def test_static_sequence_with_failure():
 
     root.tick_once()
 
+    assert root.current_child is not None
     assert_details("Current Child", failure.name, root.current_child.name)
     assert root.tip().name == failure.name, 'should execute first 2 nodes of this Sequence and fail'
 
@@ -179,10 +183,12 @@ def test_add_tick_add_with_current_child():
     root.add_child(run1)
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert(root.current_child.name == run1.name)
     root.add_child(run2)
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert(root.current_child.name == run1.name)
 
@@ -196,10 +202,12 @@ def test_add_tick_insert_with_current_child():
     root.add_child(run1)
     root.tick_once()
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert(root.current_child.name == run1.name)
     root.insert_child(run2, index=0)
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", run1.name, root.current_child.name)
     assert(root.current_child.name == run1.name)
 
@@ -214,6 +222,7 @@ def test_add_tick_remove_with_current_child():
     print(py_trees.display.unicode_tree(root, show_status=True))
     root.remove_child(child)
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", None, root.current_child)
     assert(root.current_child is None)
 
@@ -222,6 +231,7 @@ def test_add_tick_remove_with_current_child():
     print(py_trees.display.unicode_tree(root, show_status=True))
     root.remove_all_children()
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", None, root.current_child)
     assert(root.current_child is None)
 
@@ -231,6 +241,7 @@ def test_add_tick_remove_with_current_child():
     print(py_trees.display.unicode_tree(root, show_status=True))
     root.replace_child(child=child, replacement=replacement)
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", None, root.current_child)
     assert(root.current_child is None)
 
@@ -240,5 +251,6 @@ def test_add_tick_remove_with_current_child():
     print(py_trees.display.unicode_tree(root, show_status=True))
     root.remove_child_by_id(child_id=child.id)
     print(py_trees.display.unicode_tree(root, show_status=True))
+    assert root.current_child is not None
     assert_details("Current Child", None, root.current_child)
     assert(root.current_child is None)

--- a/tests/test_tip.py
+++ b/tests/test_tip.py
@@ -144,6 +144,8 @@ def test_decorator():
     console.banner("Decorators")
     print("\n--------- Assertions ---------\n")
 
+    root: py_trees.behaviour.Behaviour
+
     # Decorators are the exception, when they reach SUCCESS||FAILURE and
     # the child is RUNNING they invalidate their children, so look to the
     # decorator, not the child!

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -570,7 +570,7 @@ def test_tree_setup():
     assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
-    print(console.cyan + "Short timeout: " + console.yellow + "No Visitor" + console.reset)
+    print(console.cyan + "Long timeout: " + console.yellow + "No Visitor" + console.reset)
     try:
         tree.setup(timeout=4 * duration)
     except RuntimeError:
@@ -579,7 +579,7 @@ def test_tree_setup():
     assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
-    print(console.cyan + "Long Timeout: " + console.yellow + "With Visitor" + console.reset)
+    print(console.cyan + "Short Timeout: " + console.yellow + "With Visitor" + console.reset)
     visitor = SetupVisitor()
     with nose.tools.assert_raises(RuntimeError) as context:
         tree.setup(timeout=2 * duration, visitor=visitor)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -510,7 +510,7 @@ def test_failed_tree():
     tree.tick()
     print("\n--------- Assertions ---------\n")
     print("root.tip().name == Failure 3")
-    assert(root.tip().name == "Failure 3")
+    assert root.tip().name == "Failure 3"
 
     # TODO failed sequence tree
 
@@ -522,7 +522,7 @@ def test_tree_errors():
     with nose.tools.assert_raises(TypeError) as context:
         unused_tree = py_trees.trees.BehaviourTree(root)
         print("TypeError has message with substring 'must be an instance of'")
-        assert("must be an instance of" in str(context.exception))
+        assert "must be an instance of" in str(context.exception)
 
     root = py_trees.behaviours.Success()
     print("__init__ raises a 'RuntimeError' because we try to prune the root node")
@@ -530,7 +530,7 @@ def test_tree_errors():
         tree = py_trees.trees.BehaviourTree(root)
         tree.prune_subtree(root.id)
         print("RuntimeError has message with substring 'prune'")
-        assert("prune" in str(context.exception))
+        assert "prune" in str(context.exception)
 
     root = py_trees.behaviours.Success()
     new_subtree = py_trees.behaviours.Success()
@@ -539,7 +539,7 @@ def test_tree_errors():
         tree = py_trees.trees.BehaviourTree(root)
         tree.replace_subtree(root.id, new_subtree)
         print("RuntimeError has message with substring 'replace'")
-        assert("replace" in str(context.exception))
+        assert "replace" in str(context.exception)
 
     root = py_trees.behaviours.Success()
     new_subtree = py_trees.behaviours.Success()
@@ -548,7 +548,7 @@ def test_tree_errors():
         tree = py_trees.trees.BehaviourTree(root)
         tree.insert_subtree(child=new_subtree, unique_id=root.id, index=0)
         print("TypeError has message with substring 'Composite'")
-        assert("Composite" in str(context.exception))
+        assert "Composite" in str(context.exception)
 
 
 def test_tree_setup():
@@ -567,7 +567,7 @@ def test_tree_setup():
     print("RuntimeError has message with substring 'timed out'")
     assert("timed out" in str(context.exception))
     active_threads = threading.active_count()
-    assert(active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads))
+    assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
     print(console.cyan + "Short timeout: " + console.yellow + "No Visitor" + console.reset)
@@ -576,7 +576,7 @@ def test_tree_setup():
     except RuntimeError:
         assert False, "should not have timed out"
     active_threads = threading.active_count()
-    assert(active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads))
+    assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
     print(console.cyan + "Long Timeout: " + console.yellow + "With Visitor" + console.reset)
@@ -586,7 +586,7 @@ def test_tree_setup():
     print("RuntimeError has message with substring 'timed out'")
     assert("timed out" in str(context.exception))
     active_threads = threading.active_count()
-    assert(active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads))
+    assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
     print(console.cyan + "Long timeout: " + console.yellow + "With Visitor" + console.reset)
@@ -596,7 +596,7 @@ def test_tree_setup():
     except RuntimeError:
         assert False, "should not have timed out"
     active_threads = threading.active_count()
-    assert(active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads))
+    assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
     print("\n--------- Assertions ---------\n")
     print(console.cyan + "No timeout: " + console.yellow + "No Visitor" + console.reset)
@@ -606,7 +606,7 @@ def test_tree_setup():
     except RuntimeError:
         assert False, "should not have timed out"
     active_threads = threading.active_count()
-    assert(active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads))
+    assert active_threads == 1, "Only one thread should be active but there are {} active".format(active_threads)
 
 
 def test_pre_post_tick_activity_sequence():
@@ -647,14 +647,14 @@ def test_pre_post_tick_activity_sequence():
         "one_shot_post_tick_handler"
     ]
     print("")
-    assert(len(breadcrumbs) == len(expected_breadcrumbs))
+    assert len(breadcrumbs) == len(expected_breadcrumbs)
     for expected, actual in zip(expected_breadcrumbs, breadcrumbs):
         print(
             console.green + "Breadcrumb..................." +
             console.cyan + "{} ".format(expected) +
             console.yellow + "[{}]".format(actual)
         )
-        assert(expected == actual)
+        assert expected == actual
 
 
 def test_unicode_tree_debug():

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -517,10 +517,10 @@ def test_failed_tree():
 
 def test_tree_errors():
     console.banner("Tree Errors")
-    root = 5.0
+    float_root = 5.0
     print("__init__ raises a 'TypeError' due to invalid root variable type being passed")
     with nose.tools.assert_raises(TypeError) as context:
-        unused_tree = py_trees.trees.BehaviourTree(root)
+        unused_tree = py_trees.trees.BehaviourTree(float_root)  # type: ignore
         print("TypeError has message with substring 'must be an instance of'")
         assert "must be an instance of" in str(context.exception)
 


### PR DESCRIPTION
This PR enables "check_untyped_defs" which allows mypy to check functions (defs) that don't have explicit typing in their headers. This found many issues, which I resolved, mostly in good ways, sometimes with a hammer. Once merged, I believe this additional type checking will help encourage better code structure, there are aspects of the code that become apparent now with the type checking that could be refactored to be cleaner in the future.

I actually found a few bugs (mostly around logging) as a result, and the code is overall a bit more rigorous with assertions and type checking.

**Note**: This PR builds on top of https://github.com/splintered-reality/py_trees/pull/338, so for ease of review I'd recommend merging that PR first, then this one. This one is really only a single commit, but shows as many because the other PR is not yet merged. Once merged, it will be a cleaner diff.