### PR TITLE
doc: Add py_trees.common.Access to modules.rst

### DIFF
--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -40,6 +40,10 @@ py_trees.common
 .. automodule:: py_trees.common
     :synopsis: common definitions, methods and enumerations
 
+.. autoclass:: py_trees.common.Access
+   :members: READ, WRITE, EXCLUSIVE_WRITE
+   :show-inheritance:
+
 .. autoclass:: py_trees.common.BlackBoxLevel
     :members: BIG_PICTURE, COMPONENT, DETAIL, NOT_A_BLACKBOX
     :show-inheritance:
@@ -62,10 +66,6 @@ py_trees.common
 .. autoclass:: py_trees.common.Status
     :members: SUCCESS, FAILURE, RUNNING, INVALID
     :show-inheritance:
-
-.. autoclass:: py_trees.common.Access
-   :members: READ, WRITE, EXCLUSIVE_WRITE
-   :show-inheritance:
 
 .. autoclass:: py_trees.common.VisibilityLevel
     :members: ALL, DETAIL, COMPONENT, BIG_PICTURE

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -63,6 +63,10 @@ py_trees.common
     :members: SUCCESS, FAILURE, RUNNING, INVALID
     :show-inheritance:
 
+.. autoclass:: py_trees.common.Access
+   :members: READ, WRITE, EXCLUSIVE_WRITE
+   :show-inheritance:
+
 .. autoclass:: py_trees.common.VisibilityLevel
     :members: ALL, DETAIL, COMPONENT, BIG_PICTURE
     :show-inheritance:


### PR DESCRIPTION
When trying to link to py_trees.common.Access.WRITE in my docs, I noticed it wasn't working. After some investigation, I found that Access hadn't been specified in the docs and so wasn't being included.