### PR TITLE
[common] a practically usable inf

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Release Notes
 
 Forthcoming
 -----------
+* [common] a practical inf, `#366 <https://github.com/splintered-reality/py_trees/pull/366>`_
 * [composites] avoid redundant stop for non-running children `#360 <https://github.com/splintered-reality/py_trees/pull/360>`_
 * [display] bugfix unicode use when no unicode for dot `#359 <https://github.com/splintered-reality/py_trees/pull/359>`_
 * [tests] use tox, flake8 in prem-merge `#354 <https://github.com/splintered-reality/py_trees/pull/354>`_

--- a/py_trees/common.py
+++ b/py_trees/common.py
@@ -16,7 +16,7 @@ Common definitions, methods and variables used by the py_trees library.
 ##############################################################################
 
 import enum
-import math
+import sys
 import typing
 
 ##############################################################################
@@ -53,9 +53,9 @@ class Duration(enum.Enum):
     Naming conventions.
     """
 
-    INFINITE = math.inf
+    INFINITE = sys.float_info.max
     """:py:data:`~py_trees.common.Duration.INFINITE` oft used for perpetually blocking operations."""
-    UNTIL_THE_BATTLE_OF_ALFREDO = math.inf
+    UNTIL_THE_BATTLE_OF_ALFREDO = sys.float_info.max
     """:py:data:`~py_trees.common.Duration.UNTIL_THE_BATTLE_OF_ALFREDO` is an alias for
     :py:data:`~py_trees.common.Duration.INFINITE`."""
 


### PR DESCRIPTION
An upper bound to represent blocking may as well be an actual float, which can then be used in implementations without it tripping up, e.g. validators that don't know how to handle an inf value.

This could be backported to earlier versions if desired, `sys.float_info.max` seems to have been around for at least all of python 3.