### PR TITLE
[composites] use explicit composite arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Release Notes
 
 Forthcoming
 -----------
+* [composites] use explicit composite arguments, `#370 <https://github.com/splintered-reality/py_trees/pull/370>`_
 * [composites] restart the sequence, but allow children to retain their state `#368 <https://github.com/splintered-reality/py_trees/pull/368>`_
 * [common] a practical inf, `#366 <https://github.com/splintered-reality/py_trees/pull/366>`_
 * [composites] avoid redundant stop for non-running children `#360 <https://github.com/splintered-reality/py_trees/pull/360>`_

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -41,7 +41,7 @@ well be back at the terminal parsing code.
 
 The basic operational modes of the three composites in this library are as follows:
 
-* :class:`~py_trees.composites.Selector`: select a child to execute based on cascading priorities
+* :class:`~py_trees.composites.Selector`: execute a child based on cascading priorities
 * :class:`~py_trees.composites.Sequence`: execute children sequentially
 * :class:`~py_trees.composites.Parallel`: execute children concurrently
 
@@ -295,13 +295,18 @@ class Selector(Composite):
     .. seealso:: The :ref:`py-trees-demo-selector-program` program demos higher priority switching under a selector.
 
     Args:
-        name (:obj:`str`): the composite behaviour name
         memory (:obj:`bool`): if :data:`~py_trees.common.Status.RUNNING` on the previous tick,
             resume with the :data:`~py_trees.common.Status.RUNNING` child
+        name (:obj:`str`): the composite behaviour name
         children ([:class:`~py_trees.behaviour.Behaviour`]): list of children to add
     """
 
-    def __init__(self, name="Selector", memory=False, children=None):
+    def __init__(
+        self,
+        name: str,
+        memory: bool,
+        children: typing.List[behaviour.Behaviour] = None
+    ):
         super(Selector, self).__init__(name, children)
         self.memory = memory
 
@@ -421,8 +426,8 @@ class Sequence(Composite):
 
     def __init__(
         self,
-        name: str = "Sequence",
-        memory: bool = True,
+        name: str,
+        memory: bool,
         children: typing.List[behaviour.Behaviour] = None
     ):
         super(Sequence, self).__init__(name, children)
@@ -550,8 +555,8 @@ class Parallel(Composite):
     """
 
     def __init__(self,
-                 name: typing.Union[str, common.Name] = common.Name.AUTO_GENERATED,
-                 policy: common.ParallelPolicy.Base = None,
+                 name: typing.Union[str, common.Name],
+                 policy: common.ParallelPolicy.Base,
                  children: typing.List[behaviour.Behaviour] = None
                  ):
         """
@@ -562,8 +567,6 @@ class Parallel(Composite):
             policy: policy for deciding success or otherwise (default: SuccessOnAll)
             children: list of children to add
         """
-        if policy is None:
-            policy = common.ParallelPolicy.SuccessOnAll()
         super(Parallel, self).__init__(name, children)
         self.policy = policy
 

--- a/py_trees/demos/blackboard.py
+++ b/py_trees/demos/blackboard.py
@@ -170,7 +170,7 @@ class ParamsAndState(py_trees.behaviour.Behaviour):
 
 
 def create_root():
-    root = py_trees.composites.Sequence("Blackboard Demo")
+    root = py_trees.composites.Sequence(name="Blackboard Demo", memory=True)
     set_blackboard_variable = py_trees.behaviours.SetBlackboardVariable(
         name="Set Nested", variable_name="nested", variable_value=Nested()
     )

--- a/py_trees/demos/context_switching.py
+++ b/py_trees/demos/context_switching.py
@@ -124,7 +124,7 @@ class ContextSwitch(py_trees.behaviour.Behaviour):
 def create_root():
     root = py_trees.composites.Parallel(name="Parallel", policy=py_trees.common.ParallelPolicy.SuccessOnOne())
     context_switch = ContextSwitch(name="Context")
-    sequence = py_trees.composites.Sequence(name="Sequence")
+    sequence = py_trees.composites.Sequence(name="Sequence", memory=True)
     for job in ["Action 1", "Action 2"]:
         success_after_two = py_trees.behaviours.Count(name=job,
                                                       fail_until=0,

--- a/py_trees/demos/display_modes.py
+++ b/py_trees/demos/display_modes.py
@@ -79,17 +79,17 @@ def create_root() -> py_trees.behaviour.Behaviour:
     Returns:
         the root of the tree
     """
-    root = py_trees.composites.Sequence(name="root")
-    child = py_trees.composites.Sequence(name="child1")
-    child2 = py_trees.composites.Sequence(name="child2")
-    child3 = py_trees.composites.Sequence(name="child3")
+    root = py_trees.composites.Sequence(name="root", memory=True)
+    child = py_trees.composites.Sequence(name="child1", memory=True)
+    child2 = py_trees.composites.Sequence(name="child2", memory=True)
+    child3 = py_trees.composites.Sequence(name="child3", memory=True)
     root.add_child(child)
     root.add_child(child2)
     root.add_child(child3)
 
     child.add_child(py_trees.behaviours.Count(name='Count', fail_until=0, running_until=1, success_until=6,))
     child2.add_child(py_trees.behaviours.Count(name='Count', fail_until=0, running_until=1, success_until=6,))
-    child2_child1 = py_trees.composites.Sequence(name="Child2_child1")
+    child2_child1 = py_trees.composites.Sequence(name="Child2_child1", memory=True)
     child2_child1.add_child(py_trees.behaviours.Count(name='Count', fail_until=0, running_until=1, success_until=6,))
     child2.add_child(child2_child1)
     child3.add_child(py_trees.behaviours.Count(name='Count', fail_until=0, running_until=1, success_until=6,))

--- a/py_trees/demos/dot_graphs.py
+++ b/py_trees/demos/dot_graphs.py
@@ -84,18 +84,18 @@ def command_line_argument_parser():
 
 
 def create_tree(level):
-    root = py_trees.composites.Selector("Demo Dot Graphs %s" % level)
-    first_blackbox = py_trees.composites.Sequence("BlackBox 1")
+    root = py_trees.composites.Selector(name="Demo Dot Graphs %s" % level, memory=False)
+    first_blackbox = py_trees.composites.Sequence(name="BlackBox 1", memory=True)
     first_blackbox.add_child(py_trees.behaviours.Running("Worker"))
     first_blackbox.add_child(py_trees.behaviours.Running("Worker"))
     first_blackbox.add_child(py_trees.behaviours.Running("Worker"))
     first_blackbox.blackbox_level = py_trees.common.BlackBoxLevel.BIG_PICTURE
-    second_blackbox = py_trees.composites.Sequence("Blackbox 2")
+    second_blackbox = py_trees.composites.Sequence(name="Blackbox 2", memory=True)
     second_blackbox.add_child(py_trees.behaviours.Running("Worker"))
     second_blackbox.add_child(py_trees.behaviours.Running("Worker"))
     second_blackbox.add_child(py_trees.behaviours.Running("Worker"))
     second_blackbox.blackbox_level = py_trees.common.BlackBoxLevel.COMPONENT
-    third_blackbox = py_trees.composites.Sequence("Blackbox 3")
+    third_blackbox = py_trees.composites.Sequence(name="Blackbox 3", memory=True)
     third_blackbox.add_child(py_trees.behaviours.Running("Worker"))
     third_blackbox.add_child(py_trees.behaviours.Running("Worker"))
     third_blackbox.add_child(py_trees.behaviours.Running("Worker"))

--- a/py_trees/demos/either_or.py
+++ b/py_trees/demos/either_or.py
@@ -154,13 +154,13 @@ def create_root():
         name="Root",
         policy=py_trees.common.ParallelPolicy.SuccessOnAll(synchronise=False)
     )
-    reset = py_trees.composites.Sequence(name="Reset")
+    reset = py_trees.composites.Sequence(name="Reset", memory=True)
     reset.add_children([reset_joystick_one, reset_joystick_two])
-    joystick_one_events = py_trees.composites.Sequence(name="Joy1 Events")
+    joystick_one_events = py_trees.composites.Sequence(name="Joy1 Events", memory=True)
     joystick_one_events.add_children([trigger_one, enable_joystick_one])
-    joystick_two_events = py_trees.composites.Sequence(name="Joy2 Events")
+    joystick_two_events = py_trees.composites.Sequence(name="Joy2 Events", memory=True)
     joystick_two_events.add_children([trigger_two, enable_joystick_two])
-    tasks = py_trees.composites.Selector(name="Tasks")
+    tasks = py_trees.composites.Selector(name="Tasks", memory=False)
     tasks.add_children([either_or, idle])
     root.add_children([reset, joystick_one_events, joystick_two_events, tasks])
     return root

--- a/py_trees/demos/logging.py
+++ b/py_trees/demos/logging.py
@@ -127,7 +127,7 @@ def logger(snapshot_visitor, behaviour_tree):
 
 def create_tree():
     every_n_success = py_trees.behaviours.SuccessEveryN("EveryN", 5)
-    sequence = py_trees.composites.Sequence(name="Sequence")
+    sequence = py_trees.composites.Sequence(name="Sequence", memory=True)
     guard = py_trees.behaviours.Success("Guard")
     periodic_success = py_trees.behaviours.Periodic("Periodic", 3)
     finisher = py_trees.behaviours.Success("Finisher")
@@ -136,7 +136,7 @@ def create_tree():
     sequence.add_child(finisher)
     sequence.blackbox_level = py_trees.common.BlackBoxLevel.COMPONENT
     idle = py_trees.behaviours.Success("Idle")
-    root = py_trees.composites.Selector(name="Logging")
+    root = py_trees.composites.Selector(name="Logging", memory=False)
     root.add_child(every_n_success)
     root.add_child(sequence)
     root.add_child(idle)

--- a/py_trees/demos/pick_up_where_you_left_off.py
+++ b/py_trees/demos/pick_up_where_you_left_off.py
@@ -126,7 +126,7 @@ def create_root():
         name="Pick Up\nWhere You\nLeft Off",
         tasks=[task_one, task_two]
     )
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     root.add_children([high_priority_interrupt, piwylo])
 
     return root

--- a/py_trees/demos/selector.py
+++ b/py_trees/demos/selector.py
@@ -74,7 +74,7 @@ def command_line_argument_parser():
 
 
 def create_root():
-    root = py_trees.composites.Selector("Selector")
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     success_after_two = py_trees.behaviours.Count(name="After Two",
                                                   fail_until=2,
                                                   running_until=2,

--- a/py_trees/demos/sequence.py
+++ b/py_trees/demos/sequence.py
@@ -73,7 +73,7 @@ def command_line_argument_parser():
 
 
 def create_root():
-    root = py_trees.composites.Sequence("Sequence")
+    root = py_trees.composites.Sequence(name="Sequence", memory=True)
     for action in ["Action 1", "Action 2", "Action 3"]:
         success_after_two = py_trees.behaviours.Count(name=action,
                                                       fail_until=0,

--- a/py_trees/demos/stewardship.py
+++ b/py_trees/demos/stewardship.py
@@ -134,7 +134,7 @@ class Finisher(py_trees.behaviour.Behaviour):
 
 def create_tree():
     every_n_success = SuccessEveryN()
-    sequence = py_trees.composites.Sequence(name="Sequence")
+    sequence = py_trees.composites.Sequence(name="Sequence", memory=True)
     guard = py_trees.behaviours.Success("Guard")
     periodic_success = PeriodicSuccess()
     finisher = Finisher()
@@ -142,7 +142,7 @@ def create_tree():
     sequence.add_child(periodic_success)
     sequence.add_child(finisher)
     idle = py_trees.behaviours.Success("Idle")
-    root = py_trees.composites.Selector(name="Demo Tree")
+    root = py_trees.composites.Selector(name="Demo Tree", memory=False)
     root.add_child(every_n_success)
     root.add_child(sequence)
     root.add_child(idle)

--- a/py_trees/display.py
+++ b/py_trees/display.py
@@ -266,7 +266,7 @@ def ascii_tree(
                     )
                 )
 
-            root = py_trees.composites.Sequence("Sequence")
+            root = py_trees.composites.Sequence(name="Sequence", memory=True)
             for action in ["Action 1", "Action 2", "Action 3"]:
                 b = py_trees.behaviours.Count(
                         name=action,
@@ -368,7 +368,7 @@ def xhtml_tree(
             import py_trees
             a = py_trees.behaviours.Success()
             b = py_trees.behaviours.Success()
-            c = c = py_trees.composites.Sequence(children=[a, b])
+            c = c = py_trees.composites.Sequence(name="Sequence", memory=True, children=[a, b])
             c.tick_once()
 
             f = open('testies.html', 'w')
@@ -661,7 +661,7 @@ def render_dot_tree(root: behaviour.Behaviour,
 
         .. code-block:: python
 
-            root = py_trees.composites.Sequence("Sequence")
+            root = py_trees.composites.Sequence(name="Sequence", memory=True)
             for job in ["Action 1", "Action 2", "Action 3"]:
                 success_after_two = py_trees.behaviours.Count(name=job,
                                                               fail_until=0,

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -44,7 +44,7 @@ def assert_details(text, expected, result):
 
 def test_replacing_children():
     console.banner("Replacing Children")
-    parent = py_trees.composites.Sequence(name="Parent")
+    parent = py_trees.composites.Sequence(name="Parent", memory=True)
     front = py_trees.behaviours.Success(name="Front")
     back = py_trees.behaviours.Success(name="Back")
     old_child = py_trees.behaviours.Success(name="Old Child")
@@ -62,7 +62,7 @@ def test_replacing_children():
 
 def test_removing_children():
     console.banner("Removing Children")
-    parent = py_trees.composites.Sequence(name="Parent")
+    parent = py_trees.composites.Sequence(name="Parent", memory=True)
     child = py_trees.behaviours.Success(name="Child")
     print("\n--------- Assertions ---------\n")
     print("child.parent is None after removing by instance")
@@ -81,7 +81,7 @@ def test_removing_children():
 
 def test_composite_add_child_exception():
     console.banner("Composite Add Child Exception - Invalid Type")
-    root = py_trees.composites.Selector()
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     with pytest.raises(TypeError) as context:  # if raised, context survives
         root.add_child(5.0)
         py_trees.tests.print_assert_details("TypeError raised", "raised", "not raised")
@@ -94,8 +94,8 @@ def test_composite_add_child_exception():
 def test_protect_against_multiple_parents():
     console.banner("Protect Against Multiple Parents")
     child = py_trees.behaviours.Success()
-    first_parent = py_trees.composites.Selector()
-    second_parent = py_trees.composites.Sequence()
+    first_parent = py_trees.composites.Selector(name="Selector", memory=False)
+    second_parent = py_trees.composites.Sequence(name="Sequence", memory=True)
     with pytest.raises(RuntimeError) as context:  # if raised, context survives
         # Adding a child to two parents - expecting a RuntimeError
         for parent in [first_parent, second_parent]:
@@ -109,7 +109,7 @@ def test_protect_against_multiple_parents():
 
 def test_remove_nonexistant_child():
     console.banner("Remove non-existant child")
-    root = py_trees.composites.Sequence(name="Sequence")
+    root = py_trees.composites.Sequence(name="Sequence", memory=True)
     child = py_trees.behaviours.Success(name="Success")
     root.add_child(child)
     non_existant_child = py_trees.behaviours.Success(name="Ooops")

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -51,7 +51,7 @@ def test_invalid_child():
 
 def test_failure_is_success_tree():
     console.banner("Failure is Success Tree")
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     failure = py_trees.behaviours.Failure(name="Failure")
     failure_is_success = py_trees.decorators.FailureIsSuccess(
         child=py_trees.behaviours.Failure()
@@ -75,7 +75,7 @@ def test_failure_is_success_tree():
 
 def test_failure_is_running_tree():
     console.banner("Failure is Running Tree")
-    root = py_trees.composites.Parallel(name="Root")
+    root = py_trees.composites.Parallel(name="Root", policy=py_trees.common.ParallelPolicy.SuccessOnAll())
     running = py_trees.decorators.FailureIsRunning(
         child=py_trees.behaviours.Running()
     )
@@ -110,7 +110,7 @@ def test_failure_is_running_tree():
 
 def test_running_is_success_tree():
     console.banner("Running is Success Tree")
-    root = py_trees.composites.Parallel(name="Root")
+    root = py_trees.composites.Parallel(name="Root", policy=py_trees.common.ParallelPolicy.SuccessOnAll())
     running = py_trees.decorators.RunningIsSuccess(
         child=py_trees.behaviours.Running()
     )
@@ -145,11 +145,11 @@ def test_running_is_success_tree():
 
 def test_success_is_running_tree():
     console.banner("Success is Running Tree")
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     failure = py_trees.decorators.SuccessIsRunning(
         child=py_trees.behaviours.Failure()
     )
-    parallel = py_trees.composites.Parallel(name="Parallel")
+    parallel = py_trees.composites.Parallel(name="Parallel", policy=py_trees.common.ParallelPolicy.SuccessOnAll())
     running = py_trees.decorators.SuccessIsRunning(
         child=py_trees.behaviours.Running()
     )
@@ -184,7 +184,7 @@ def test_success_is_running_tree():
 
 def test_success_is_failure_tree():
     console.banner("Success is Failure Tree")
-    root = py_trees.composites.Selector("Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     failure = py_trees.behaviours.Failure(name="Failure")
     success_is_failure = py_trees.decorators.SuccessIsFailure(
         name="Success Is Failure",
@@ -209,8 +209,8 @@ def test_success_is_failure_tree():
 
 def test_inverter():
     console.banner("Inverter")
-    root = py_trees.composites.Sequence(name="Root")
-    selector = py_trees.composites.Selector(name="Selector")
+    root = py_trees.composites.Sequence(name="Root", memory=True)
+    selector = py_trees.composites.Selector(name="Selector", memory=False)
     failure = py_trees.behaviours.Failure(name="Failure")
     success_inverter = py_trees.decorators.Inverter(child=py_trees.behaviours.Success())
     success = py_trees.behaviours.Success(name="Success")
@@ -246,7 +246,7 @@ def test_inverter():
 
 def test_running_is_failure_tree():
     console.banner("Running is Failure Tree")
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     running = py_trees.decorators.RunningIsFailure(
         child=py_trees.behaviours.Running()
     )

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -50,7 +50,7 @@ def test_symbols():
 def test_text_trees():
     console.banner("Text Trees")
 
-    root = py_trees.composites.Selector("Selector")
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     high_priority = py_trees.behaviours.Count(
         name="High Priority",
         fail_until=1,
@@ -58,8 +58,8 @@ def test_text_trees():
         success_until=10
     )
     low_priority = py_trees.behaviours.Running(name="Low Priority")
-    selector_with_memory = py_trees.composites.Selector("Selector w/ Memory", memory=True)
-    sequence_with_memory = py_trees.composites.Selector("Sequence w/ Memory", memory=True)
+    selector_with_memory = py_trees.composites.Selector(name="Selector w/ Memory", memory=True)
+    sequence_with_memory = py_trees.composites.Sequence(name="Sequence w/ Memory", memory=True)
     success = py_trees.behaviours.Success("Success")
     selector_with_memory.add_child(success)
     root.add_children([high_priority, low_priority, selector_with_memory, sequence_with_memory])
@@ -139,7 +139,7 @@ def test_ascii_snapshot_priority_interrupt():
             )
         )
 
-    root = py_trees.composites.Selector("Selector")
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     root.add_child(
         py_trees.behaviours.Count(
             name="High Priority",

--- a/tests/test_either_or.py
+++ b/tests/test_either_or.py
@@ -89,13 +89,13 @@ def create_root():
         name="Root",
         policy=py_trees.common.ParallelPolicy.SuccessOnAll(synchronise=False)
     )
-    reset = py_trees.composites.Sequence(name="Reset")
+    reset = py_trees.composites.Sequence(name="Reset", memory=True)
     reset.add_children([reset_joystick_one, reset_joystick_two])
-    joystick_one_events = py_trees.composites.Sequence(name="Joy1 Events")
+    joystick_one_events = py_trees.composites.Sequence(name="Joy1 Events", memory=True)
     joystick_one_events.add_children([trigger_one, enable_joystick_one])
-    joystick_two_events = py_trees.composites.Sequence(name="Joy2 Events")
+    joystick_two_events = py_trees.composites.Sequence(name="Joy2 Events", memory=True)
     joystick_two_events.add_children([trigger_two, enable_joystick_two])
-    tasks = py_trees.composites.Selector(name="Tasks")
+    tasks = py_trees.composites.Selector(name="Tasks", memory=False)
     tasks.add_children([either_or, idle])
     root.add_children([reset, joystick_one_events, joystick_two_events, tasks])
     return root, task_one, task_two

--- a/tests/test_eternal_guard.py
+++ b/tests/test_eternal_guard.py
@@ -78,7 +78,7 @@ def generate_eternal_guard():
         py_trees.behaviours.Success(name="Success")
     ]
     tasks = create_tasks()
-    task_sequence = py_trees.composites.Sequence("Task Sequence")
+    task_sequence = py_trees.composites.Sequence(name="Task Sequence", memory=True)
     task_sequence.add_children(tasks)
     eternal_guard = py_trees.idioms.eternal_guard(
         name="Eternal Guard",
@@ -89,7 +89,7 @@ def generate_eternal_guard():
 
 
 def test_eternal_guard_idiom():
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     eternal_guard, tasks = generate_eternal_guard()
     idle = py_trees.behaviours.Running()
 
@@ -112,7 +112,7 @@ def test_eternal_guard_unique_names():
         blackboard.register_key(key=key, access=py_trees.common.Access.WRITE)
     message = "Ha, stole it"
     blackboard.eternal_guard_condition_1 = message
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     eternal_guard, unused_tasks = generate_eternal_guard()
     root.add_children([eternal_guard])
     # tick once, get variables on the blackboard
@@ -129,7 +129,7 @@ def test_eternal_guard_unique_names():
 
 
 def test_eternal_guard_decorator():
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
 
     def condition_success():
         return True
@@ -155,7 +155,7 @@ def test_eternal_guard_decorator():
                 return py_trees.common.Status.FAILURE
 
     tasks = create_tasks()
-    task_sequence = py_trees.composites.Sequence("Task Sequence")
+    task_sequence = py_trees.composites.Sequence(name="Task Sequence", memory=True)
     task_sequence.add_children(tasks)
     idle = py_trees.behaviours.Running()
     nested_guard = py_trees.decorators.EternalGuard(

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -116,6 +116,7 @@ def test_oneshot_with_fail_causes_reentry():
 def untest_oneshot_with_subtrees_and_interrupt():
     sequence_subtree = py_trees.composites.Sequence(
         name="Sequence",
+        memory=True,
         children=[
             py_trees.behaviours.Success(name="Success 1"),
             py_trees.behaviours.Success(name="Success 2")
@@ -123,6 +124,7 @@ def untest_oneshot_with_subtrees_and_interrupt():
     )
     selector_subtree = py_trees.composites.Selector(
         name="Selector",
+        memory=False,
         children=[
             py_trees.behaviours.Failure(name="Failure"),
             py_trees.behaviours.Success(name="Success")
@@ -141,7 +143,7 @@ def untest_oneshot_with_subtrees_and_interrupt():
             py_trees.tests.clear_blackboard()
 
             # Tree with higher priority branch
-            root = py_trees.composites.Selector(name="Root")
+            root = py_trees.composites.Selector(name="Root", memory=False)
             fail_after_one = py_trees.behaviours.Count(
                 name="HighPriority", fail_until=1, running_until=1, success_until=2)
             root.add_children([fail_after_one, oneshot])

--- a/tests/test_parallels.py
+++ b/tests/test_parallels.py
@@ -49,7 +49,7 @@ def test_parallel_failure():
     success_on_all_synchronised = py_trees.common.ParallelPolicy.SuccessOnAll(synchronise=True)
     success_on_all_not_synchronised = py_trees.common.ParallelPolicy.SuccessOnAll(synchronise=False)
     for policy in [success_on_one, success_on_all_synchronised, success_on_all_not_synchronised]:
-        root = py_trees.composites.Parallel("Parallel", policy=policy)
+        root = py_trees.composites.Parallel(name="Parallel", policy=policy)
         failure = py_trees.behaviours.Failure("Failure")
         success = py_trees.behaviours.Success("Success")
         root.add_child(failure)
@@ -70,7 +70,7 @@ def test_parallel_failure():
     success = py_trees.behaviours.Success("Success")
     for child, synchronise in itertools.product([success, failure], [True, False]):
         policy = py_trees.common.ParallelPolicy.SuccessOnSelected(children=[child], synchronise=synchronise)
-        root = py_trees.composites.Parallel("Parallel", policy=policy)
+        root = py_trees.composites.Parallel(name="Parallel", policy=policy)
         root.add_child(failure)
         root.add_child(success)
         print(py_trees.display.unicode_tree(root))
@@ -92,7 +92,7 @@ def test_parallel_failure():
 
 def test_parallel_success():
     console.banner("Parallel Success")
-    root = py_trees.composites.Parallel("Parallel")
+    root = py_trees.composites.Parallel(name="Parallel", policy=py_trees.common.ParallelPolicy.SuccessOnAll())
     success1 = py_trees.behaviours.Success("Success1")
     success2 = py_trees.behaviours.Success("Success2")
     root.add_child(success1)
@@ -113,7 +113,9 @@ def test_parallel_success():
 def test_parallel_running():
     console.banner("Parallel Running")
     root = py_trees.composites.Parallel(
-        "Parallel", policy=py_trees.common.ParallelPolicy.SuccessOnAll())
+        name="Parallel",
+        policy=py_trees.common.ParallelPolicy.SuccessOnAll()
+    )
     success_after_1 = py_trees.behaviours.Count(
         name="SuccessAfter1",
         fail_until=0,
@@ -157,7 +159,9 @@ def test_parallel_success_on_one():
     console.banner("Parallel Success on One")
     print("")
     root = py_trees.composites.Parallel(
-        name="Parallel", policy=py_trees.common.ParallelPolicy.SuccessOnOne())
+        name="Parallel",
+        policy=py_trees.common.ParallelPolicy.SuccessOnOne()
+    )
     running1 = py_trees.behaviours.Running("Running1")
     success = py_trees.behaviours.Success("Success")
     running2 = py_trees.behaviours.Running("Running2")
@@ -247,6 +251,7 @@ def test_parallel_success_on_selected_invalid_configuration():
     )
     parallel = py_trees.composites.Parallel(
         name="Parallel",
+        policy=py_trees.common.ParallelPolicy.SuccessOnAll(),
         children=[running1, running3]
     )
     for policy in [different_policy, empty_policy]:

--- a/tests/test_pickup.py
+++ b/tests/test_pickup.py
@@ -44,7 +44,7 @@ def test_high_priority_interrupt():
         name="Pick Up\nWhere You\nLeft Off",
         tasks=[task_one, task_two]
     )
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     root.add_children([high_priority_interrupt, piwylo])
 
     print(py_trees.display.unicode_tree(root))

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -110,7 +110,7 @@ def test_with_memory_priority_handling():
 def test_tick_add_with_current_child():
     console.banner('Tick-Add with Current Child')
     assert_banner()
-    root = py_trees.composites.Selector(name="Selector")
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     root.tick_once()
     child = py_trees.behaviours.Failure(name="Failure")
     print(py_trees.display.unicode_tree(root, show_status=True))
@@ -123,7 +123,7 @@ def test_tick_add_with_current_child():
 def test_add_tick_add_with_current_child():
     console.banner('Add-Tick-Add with Current Child')
     assert_banner()
-    root = py_trees.composites.Selector(name="Selector")
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     run1 = py_trees.behaviours.Running("Run1")
     run2 = py_trees.behaviours.Running("Run2")
     root.add_child(run1)
@@ -140,7 +140,7 @@ def test_add_tick_add_with_current_child():
 def test_add_tick_insert_with_current_child():
     console.banner('Add-Tick-Insert with Current Child')
     assert_banner()
-    root = py_trees.composites.Selector(name="Selector")
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     run1 = py_trees.behaviours.Running("Run1")
     run2 = py_trees.behaviours.Running("Run2")
     root.add_child(run1)
@@ -157,7 +157,7 @@ def test_add_tick_insert_with_current_child():
 def test_add_tick_remove_with_current_child():
     console.banner('Add-Tick-Remove with Current Child')
     assert_banner()
-    root = py_trees.composites.Selector(name="Selector")
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     child = py_trees.behaviours.Success(name="Success")
     root.add_child(child)
     root.tick_once()

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -158,7 +158,7 @@ def test_static_sequence_successes():
         success3,
         success4,
     ]
-    root = py_trees.composites.Sequence(name="Sequence", children=children)
+    root = py_trees.composites.Sequence(name="Sequence", memory=True, children=children)
 
     root.tick_once()
 
@@ -181,7 +181,7 @@ def test_static_sequence_with_failure():
         failure,
         success3,
     ]
-    root = py_trees.composites.Sequence(name="Sequence", children=children)
+    root = py_trees.composites.Sequence(name="Sequence", memory=True, children=children)
 
     root.tick_once()
 
@@ -192,7 +192,7 @@ def test_static_sequence_with_failure():
 def test_tick_add_with_current_child():
     console.banner('Tick-Add with Current Child')
     assert_banner()
-    root = py_trees.composites.Sequence(name="Sequence")
+    root = py_trees.composites.Sequence(name="Sequence", memory=True)
     root.tick_once()
     child = py_trees.behaviours.Failure(name="Failure")
     print(py_trees.display.unicode_tree(root, show_status=True))
@@ -205,7 +205,7 @@ def test_tick_add_with_current_child():
 def test_add_tick_add_with_current_child():
     console.banner('Add-Tick-Add with Current Child')
     assert_banner()
-    root = py_trees.composites.Sequence(name="Sequence")
+    root = py_trees.composites.Sequence(name="Sequence", memory=True)
     run1 = py_trees.behaviours.Running("Run1")
     run2 = py_trees.behaviours.Running("Run2")
     root.add_child(run1)
@@ -222,7 +222,7 @@ def test_add_tick_add_with_current_child():
 def test_add_tick_insert_with_current_child():
     console.banner('Add-Tick-Insert with Current Child')
     assert_banner()
-    root = py_trees.composites.Sequence(name="Sequence")
+    root = py_trees.composites.Sequence(name="Sequence", memory=True)
     run1 = py_trees.behaviours.Running("Run1")
     run2 = py_trees.behaviours.Running("Run2")
     root.add_child(run1)
@@ -239,7 +239,7 @@ def test_add_tick_insert_with_current_child():
 def test_add_tick_remove_with_current_child():
     console.banner('Add-Tick-Remove with Current Child')
     assert_banner()
-    root = py_trees.composites.Sequence(name="Sequence")
+    root = py_trees.composites.Sequence(name="Sequence", memory=True)
     child = py_trees.behaviours.Success(name="Success")
     root.add_child(child)
     root.tick_once()

--- a/tests/test_tip.py
+++ b/tests/test_tip.py
@@ -49,7 +49,7 @@ def test_single_behaviour():
 def test_sequence():
     console.banner("Sequence")
     print("\n--------- Assertions ---------\n")
-    root = py_trees.composites.Sequence(name="Root")
+    root = py_trees.composites.Sequence(name="Root", memory=True)
     running = py_trees.behaviours.Running(name="Running")
     success = py_trees.behaviours.Success(name="Success")
     root.add_children([success, running])
@@ -57,7 +57,7 @@ def test_sequence():
     print("root.tip()...................running [{}]".format(root.tip()))
     assert(root.tip() is running)
 
-    root = py_trees.composites.Sequence(name="Root")
+    root = py_trees.composites.Sequence(name="Root", memory=True)
     success_one = py_trees.behaviours.Success(name="Success 1")
     success_two = py_trees.behaviours.Success(name="Success 2")
     root.add_children([success_one, success_two])
@@ -66,7 +66,7 @@ def test_sequence():
     print("root.tip()...................Success 2 [{}]".format(root.tip().name))
     assert(root.tip() is success_two)
 
-    root = py_trees.composites.Sequence(name="Root")
+    root = py_trees.composites.Sequence(name="Root", memory=True)
     failure = py_trees.behaviours.Failure(name="Failure")
     root.add_children([failure])
     py_trees.tests.tick_tree(root, 1, 1, print_snapshot=True)
@@ -74,7 +74,7 @@ def test_sequence():
     print("root.tip()...................Failure [{}]".format(root.tip().name))
     assert(root.tip() is failure)
 
-    root = py_trees.composites.Sequence(name="Root")
+    root = py_trees.composites.Sequence(name="Root", memory=True)
     py_trees.tests.tick_tree(root, 1, 1, print_snapshot=True)
     print("root.tip()...................Root [{}]".format(root.tip().name))
     assert(root.tip() is root)
@@ -83,7 +83,7 @@ def test_sequence():
 def test_selector():
     console.banner("Selector")
     print("\n--------- Assertions ---------\n")
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     failure = py_trees.behaviours.Failure(name="Failure")
     running = py_trees.behaviours.Running(name="Running")
     root.add_children([failure, running])
@@ -91,7 +91,7 @@ def test_selector():
     print("root.tip()...................running [{}]".format(root.tip().name))
     assert(root.tip() is running)
 
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     failure = py_trees.behaviours.Failure(name="Failure")
     success = py_trees.behaviours.Success(name="Success")
     root.add_children([failure, success])
@@ -99,7 +99,7 @@ def test_selector():
     print("root.tip()...................success [{}]".format(root.tip().name))
     assert(root.tip() is success)
 
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     running = py_trees.behaviours.Running(name="Running")
     failure = py_trees.behaviours.Failure(name="Failure")
     root.add_children([running, failure])
@@ -107,7 +107,7 @@ def test_selector():
     print("root.tip()...................running [{}]".format(root.tip().name))
     assert(root.tip() is running)
 
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     success = py_trees.behaviours.Success(name="Success")
     failure = py_trees.behaviours.Failure(name="Failure")
     root.add_children([success, failure])
@@ -115,7 +115,7 @@ def test_selector():
     print("root.tip()...................success [{}]".format(root.tip().name))
     assert(root.tip() is success)
 
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     failure = py_trees.behaviours.Failure(name="Failure 1")
     failure_two = py_trees.behaviours.Failure(name="Failure 2")
     root.add_children([failure, failure_two])
@@ -123,7 +123,7 @@ def test_selector():
     print("root.tip()...................Failure 2 [{}]".format(root.tip().name))
     assert(root.tip() is failure_two)
 
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     fail_then_run = py_trees.behaviours.Count(name="Fail Then Run", fail_until=1, running_until=10)
     running = py_trees.behaviours.Running(name="Running")
     root.add_children([fail_then_run, running])
@@ -134,7 +134,7 @@ def test_selector():
     print("root.tip()...................Fail Then Run [{}]".format(root.tip().name))
     assert(root.tip() is fail_then_run)
 
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     py_trees.tests.tick_tree(root, 1, 1, print_snapshot=True)
     print("root.tip()...................Root [{}]".format(root.tip().name))
     assert(root.tip() is root)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -61,7 +61,7 @@ class SetupVisitor(py_trees.visitors.VisitorBase):
 def test_selector_composite():
     console.banner("Selector")
     visitor = py_trees.visitors.DebugVisitor()
-    tree = py_trees.composites.Selector(name='Selector')
+    tree = py_trees.composites.Selector(name='Selector', memory=False)
     a = py_trees.behaviours.Count(name="A")
     b = py_trees.behaviours.Count(name="B")
     c = py_trees.behaviours.Count(name="C", fail_until=0, running_until=3, success_until=15)
@@ -144,7 +144,7 @@ def test_mixed_tree():
     a = py_trees.behaviours.Count(
         name="A", fail_until=3, running_until=5, success_until=7, reset=False)
 
-    sequence = py_trees.composites.Sequence(name="Sequence")
+    sequence = py_trees.composites.Sequence(name="Sequence", memory=True)
     b = py_trees.behaviours.Count(
         name="B", fail_until=0, running_until=3, success_until=5, reset=False)
     c = py_trees.behaviours.Count(
@@ -154,7 +154,7 @@ def test_mixed_tree():
 
     d = py_trees.behaviours.Count(name="D", fail_until=0, running_until=3, success_until=15)
 
-    root = py_trees.composites.Selector(name="Selector")
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     root.add_child(a)
     root.add_child(sequence)
     root.add_child(d)
@@ -217,13 +217,13 @@ def test_display():
     console.banner("Display Tree")
 
     a = py_trees.behaviours.Count(name="A")
-    sequence = py_trees.composites.Sequence(name="Sequence")
+    sequence = py_trees.composites.Sequence(name="Sequence", memory=True)
     b = py_trees.behaviours.Count(name="B")
     c = py_trees.behaviours.Count(name="C")
     sequence.add_child(b)
     sequence.add_child(c)
     d = py_trees.behaviours.Count(name="D")
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     root.add_child(a)
     root.add_child(sequence)
     root.add_child(d)
@@ -238,13 +238,13 @@ def test_full_iteration():
 
     visitor = py_trees.visitors.DebugVisitor()
     a = py_trees.behaviours.Count(name="A")
-    sequence = py_trees.composites.Sequence(name="Sequence")
+    sequence = py_trees.composites.Sequence(name="Sequence", memory=True)
     b = py_trees.behaviours.Count(name="B")
     c = py_trees.behaviours.Count(name="C")
     sequence.add_child(b)
     sequence.add_child(c)
     d = py_trees.behaviours.Count(name="D")
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     root.add_child(a)
     root.add_child(sequence)
     root.add_child(d)
@@ -260,13 +260,13 @@ def test_prune_behaviour_tree():
     console.banner("Prune Behaviour Tree")
 
     a = py_trees.behaviours.Count(name="A")
-    sequence = py_trees.composites.Sequence(name="Sequence")
+    sequence = py_trees.composites.Sequence(name="Sequence", memory=True)
     b = py_trees.behaviours.Count(name="B")
     c = py_trees.behaviours.Count(name="C")
     sequence.add_child(b)
     sequence.add_child(c)
     d = py_trees.behaviours.Count(name="D")
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     root.add_child(a)
     root.add_child(sequence)
     root.add_child(d)
@@ -286,13 +286,13 @@ def test_replace_behaviour_tree():
     console.banner("Replace Behaviour Subtree")
 
     a = py_trees.behaviours.Count(name="A")
-    sequence1 = py_trees.composites.Sequence(name="Sequence1")
+    sequence1 = py_trees.composites.Sequence(name="Sequence1", memory=True)
     b = py_trees.behaviours.Count(name="B")
     c = py_trees.behaviours.Count(name="C")
     sequence1.add_child(b)
     sequence1.add_child(c)
     d = py_trees.behaviours.Count(name="D")
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     root.add_child(a)
     root.add_child(sequence1)
     root.add_child(d)
@@ -301,7 +301,7 @@ def test_replace_behaviour_tree():
     print(py_trees.display.unicode_tree(tree.root))
     assert(len(sequence1.children) == 2)
 
-    sequence2 = py_trees.composites.Sequence(name="Sequence2")
+    sequence2 = py_trees.composites.Sequence(name="Sequence2", memory=True)
     e = py_trees.behaviours.Count(name="E")
     f = py_trees.behaviours.Count(name="F")
     g = py_trees.behaviours.Count(name="G")
@@ -318,13 +318,13 @@ def test_tick_tock_behaviour_tree():
     console.banner("Tick Tock Behaviour Tree")
 
     a = py_trees.behaviours.Count(name="A")
-    sequence = py_trees.composites.Sequence(name="Sequence")
+    sequence = py_trees.composites.Sequence(name="Sequence", memory=True)
     b = py_trees.behaviours.Count(name="B")
     c = py_trees.behaviours.Count(name="C")
     sequence.add_child(b)
     sequence.add_child(c)
     d = py_trees.behaviours.Count(name="D")
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     root.add_child(a)
     root.add_child(sequence)
     root.add_child(d)
@@ -343,7 +343,7 @@ def test_tick_tock_behaviour_tree():
 
 def test_success_failure_tree():
     console.banner("Success Failure Tree")
-    root = py_trees.composites.Selector(name="Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     failure = py_trees.behaviours.Failure(name="Failure")
     failure2 = py_trees.decorators.Inverter(
         name="Failure2",
@@ -372,7 +372,7 @@ def test_tip_simple():
     console.banner("Tip Simple")
 
     # behaviours will be running the first time they are seen, then success for subsequent ticks
-    seq = py_trees.composites.Sequence(name="Sequence")
+    seq = py_trees.composites.Sequence(name="Sequence", memory=True)
     a = py_trees.behaviours.Count(name="A", fail_until=0, running_until=1, success_until=100)
     b = py_trees.behaviours.Count(name="B", fail_until=0, running_until=1, success_until=100)
     seq.add_child(a)
@@ -435,9 +435,9 @@ def test_tip_complex():
     console.banner("Tip Complex")
 
     # behaviours will be running the first time they are seen, then success for subsequent ticks
-    sel = py_trees.composites.Selector(name="Selector")
-    seq1 = py_trees.composites.Sequence(name="Sequence1")
-    seq2 = py_trees.composites.Sequence(name="Sequence2")
+    sel = py_trees.composites.Selector(name="Selector", memory=False)
+    seq1 = py_trees.composites.Sequence(name="Sequence1", memory=True)
+    seq2 = py_trees.composites.Sequence(name="Sequence2", memory=True)
 
     # selector left branch fails the two times, so seq2 behaviours run. The
     # third time it is running, stopping seq2
@@ -498,7 +498,7 @@ def test_tip_complex():
 def test_failed_tree():
     console.banner("Failed Tree")
 
-    root = py_trees.composites.Selector("Root")
+    root = py_trees.composites.Selector(name="Root", memory=False)
     f1 = py_trees.behaviours.Failure("Failure 1")
     f2 = py_trees.behaviours.Failure("Failure 2")
     f3 = py_trees.behaviours.Failure("Failure 3")
@@ -573,7 +573,7 @@ def test_tree_setup():
     first = SleepInSetup(name="First", duration=duration)
     second = SleepInSetup(name="Second", duration=duration)
     third = SleepInSetup(name="Third", duration=duration)
-    root = py_trees.composites.Sequence()
+    root = py_trees.composites.Sequence(name="Root", memory=True)
     root.add_children([first, second, third])
     tree = py_trees.trees.BehaviourTree(root=root)
     print("\n--------- Assertions ---------\n")
@@ -641,7 +641,7 @@ def test_pre_post_tick_activity_sequence():
     the correct order.
     """
     console.banner("Pre-Post Tick Activity")
-    root = py_trees.composites.Selector("Selector")
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     root.add_child(py_trees.behaviours.Success())
     tree = py_trees.trees.BehaviourTree(root=root)
     breadcrumbs = list()
@@ -689,7 +689,7 @@ def test_unicode_tree_debug():
     tree visitors is executable
     """
     console.banner("Tree Ascii Art")
-    root = py_trees.composites.Selector("Selector")
+    root = py_trees.composites.Selector(name="Selector", memory=False)
     root.add_child(
         py_trees.behaviours.Count(
             name="High Priority",

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -31,7 +31,7 @@ logger = py_trees.logging.Logger("Tests")
 def test_snapshot_visitor():
     console.banner("Snapshot Visitor")
 
-    root = py_trees.composites.Selector(name='Selector')
+    root = py_trees.composites.Selector(name='Selector', memory=False)
     a = py_trees.behaviours.Count(name="A")
     b = py_trees.behaviours.Count(name="B")
     c = py_trees.behaviours.Count(name="C", fail_until=0, running_until=3, success_until=15)


### PR DESCRIPTION
This will help with the transition from inconsistent defaults for 'memory' between selector and sequence, but will also ultimately help with introspection of code for all composite classes now that configuration of those composites comes with a (hopefully not burgeoning) number of permutations.

Resolves #326.