### PR TITLE
[behaviours|decorators|composites] abstract base classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Release Notes
 
 Forthcoming
 -----------
+* [behaviours, decorators, composites] abstract base classes, `#375 <https://github.com/splintered-reality/py_trees/pull/375>`_
 * [behaviours] StatusSequence -> StatusQueue, `#372 <https://github.com/splintered-reality/py_trees/pull/372>`_
 * [decorators] repeat and retry, `#371 <https://github.com/splintered-reality/py_trees/pull/371>`_
 * [composites] use explicit composite arguments, `#370 <https://github.com/splintered-reality/py_trees/pull/370>`_

--- a/py_trees/behaviour.py
+++ b/py_trees/behaviour.py
@@ -15,6 +15,7 @@ The core behaviour template for all py_tree behaviours.
 # Imports
 ##############################################################################
 
+import abc
 import re
 import typing
 import uuid
@@ -28,7 +29,7 @@ from . import logging
 ##############################################################################
 
 
-class Behaviour(object):
+class Behaviour(abc.ABC):
     """
     A parent class for all user definable tree behaviours.
 
@@ -88,7 +89,7 @@ class Behaviour(object):
     # User Customisable Callbacks
     ############################################
 
-    def setup(self, **kwargs):
+    def setup(self, **kwargs):  # noqa: B027
         """
         Set up and verify infrastructure (middleware connections, etc) is available.
 
@@ -152,7 +153,7 @@ class Behaviour(object):
         """
         pass
 
-    def initialise(self):
+    def initialise(self):  # noqa: B027
         """
         Execute user specified instructions prior to commencement of a new round of activity.
 
@@ -166,7 +167,7 @@ class Behaviour(object):
         """
         pass
 
-    def terminate(self, new_status):
+    def terminate(self, new_status):  # noqa: B027
         """
         Execute user specified instructions when the behaviour is stopped.
 
@@ -197,6 +198,7 @@ class Behaviour(object):
         """
         pass
 
+    @abc.abstractmethod
     def update(self):
         """
         Execute user specified instructions when the behaviour is ticked.
@@ -214,7 +216,7 @@ class Behaviour(object):
         """
         return common.Status.INVALID
 
-    def shutdown(self):
+    def shutdown(self):  # noqa: B027
         """
         Destroy setup infrastructure (the antithesis of setup).
 

--- a/py_trees/behaviours.py
+++ b/py_trees/behaviours.py
@@ -53,22 +53,22 @@ def dummy(self):
     return common.Status.RUNNING
 
 
-Success = meta.create_behaviour_from_function(success)
+Success = meta.create_behaviour_from_function(success, 'py_trees.behaviours')
 """
 Do nothing but tick over with :data:`~py_trees.common.Status.SUCCESS`.
 """
 
-Failure = meta.create_behaviour_from_function(failure)
+Failure = meta.create_behaviour_from_function(failure, 'py_trees.behaviours')
 """
 Do nothing but tick over with :data:`~py_trees.common.Status.FAILURE`.
 """
 
-Running = meta.create_behaviour_from_function(running)
+Running = meta.create_behaviour_from_function(running, 'py_trees.behaviours')
 """
 Do nothing but tick over with :data:`~py_trees.common.Status.RUNNING`.
 """
 
-Dummy = meta.create_behaviour_from_function(dummy)
+Dummy = meta.create_behaviour_from_function(dummy, 'py_trees.behaviours')
 """
 Crash test dummy used for anything dangerous.
 """
@@ -134,22 +134,22 @@ class StatusQueue(behaviour.Behaviour):
     def __init__(
             self,
             name: str,
-            sequence: typing.List[common.Status],
+            queue: typing.List[common.Status],
             eventually: typing.Optional[common.Status]
     ):
         super(StatusQueue, self).__init__(name)
-        self.sequence = sequence
+        self.queue = queue
         self.eventually = eventually
-        self.current_sequence = copy.copy(sequence)
+        self.current_queue = copy.copy(queue)
 
     def update(self):
-        if self.current_sequence:
-            status = self.current_sequence.pop(0)
+        if self.current_queue:
+            status = self.current_queue.pop(0)
         elif self.eventually is not None:
             status = self.eventually
         else:
-            self.current_sequence = copy.copy(self.sequence)
-            status = self.current_sequence.pop(0)
+            self.current_queue = copy.copy(self.queue)
+            status = self.current_queue.pop(0)
         return status
 
 

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -59,6 +59,7 @@ on one, all or a subset thereof.
 # Imports
 ##############################################################################
 
+import abc
 import itertools
 import typing
 
@@ -70,7 +71,7 @@ from . import common
 ##############################################################################
 
 
-class Composite(behaviour.Behaviour):
+class Composite(behaviour.Behaviour, abc.ABC):
     """
     The parent class to all composite behaviours.
 
@@ -93,7 +94,60 @@ class Composite(behaviour.Behaviour):
         self.current_child = None
 
     ############################################
-    # Worker Overrides
+    # Virtual
+    ############################################
+    @abc.abstractmethod
+    def tick(self):
+        """
+        Tick the composite.
+
+        All composite subclasses require a re-implementation
+        of the tick method to provide the logic for managing multiple
+        children (:meth:`~py_trees.behaviour.Behaviour.tick` merely
+        provides default logic for when there are no children).
+        """
+        pass
+
+    ############################################
+    # Unused
+    ############################################
+
+    def update(self):
+        """
+        Unused update method.
+
+        Composites should direct the flow, whilst
+        behaviours do the real work.
+
+        Such flows are a consequence of how the composite
+        interacts with it's children. The success of
+        behaviour trees depends on this logic being simple,
+        well defined and limited to a few well established
+        patterns - this is what ensures that visualising
+        a tree enables a user to quickly grasp the
+        decision making captured therein.
+
+        For the standard patterns, this logic is limited
+        to the ordering of execution and logical inferences
+        on the resulting status of the composite's children.
+
+        This is a good guideline to adhere to (i.e. don't reach
+        inside children to inference on custom variables, nor
+        reach out to the system your tree is attached to).
+
+        Implementation wise, this renders the
+        :meth:`~py_trees.behaviour.Behaviour.update` method redundant
+        as all customisation to create a simple, well defined composite
+        happens in the :meth:`~py_trees.behaviour.Behaviour.tick` method.
+
+        Bottom line, composites do not make use of this method.
+        Implementing it for subclasses of the core composites
+        will not do anything.
+        """
+        pass
+
+    ############################################
+    # Overrides
     ############################################
 
     def stop(self, new_status=common.Status.INVALID):
@@ -341,9 +395,6 @@ class Selector(Composite):
             # user specific initialisation
             self.initialise()
 
-        # customised work
-        self.update()
-
         # nothing to do
         if not self.children:
             self.current_child = None
@@ -470,9 +521,6 @@ class Sequence(Composite):
         else:
             # previous conditional checks should cover all variations
             raise RuntimeError("Sequence reached an unknown / invalid state")
-
-        # customised work
-        self.update()
 
         # nothing to do
         if not self.children:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -33,6 +33,9 @@ class DummyDecorator(py_trees.decorators.Decorator):
     def __init__(self, child, name=py_trees.common.Name.AUTO_GENERATED):
         super(DummyDecorator, self).__init__(name=name, child=child)
 
+    def update(self):
+        return py_trees.common.Status.INVALID
+
 ##############################################################################
 # Tests
 ##############################################################################
@@ -53,7 +56,7 @@ def test_repeat_until_success():
     console.banner("Repeat - Until Success")
     child = py_trees.behaviours.StatusQueue(
         name="R-S-S",
-        sequence=[
+        queue=[
             py_trees.common.Status.RUNNING,
             py_trees.common.Status.SUCCESS,
             py_trees.common.Status.SUCCESS
@@ -91,7 +94,7 @@ def test_repeat_interrupting_failure():
     console.banner("Repeat - Interrupting Failure")
     child = py_trees.behaviours.StatusQueue(
         name="R-S-F",
-        sequence=[
+        queue=[
             py_trees.common.Status.RUNNING,
             py_trees.common.Status.SUCCESS,
             py_trees.common.Status.FAILURE
@@ -129,7 +132,7 @@ def test_retry_until_success():
     console.banner("Retry - Until Success")
     child = py_trees.behaviours.StatusQueue(
         name="R-F-S",
-        sequence=[
+        queue=[
             py_trees.common.Status.RUNNING,
             py_trees.common.Status.FAILURE,
             py_trees.common.Status.SUCCESS
@@ -173,7 +176,7 @@ def test_retry_eventual_failure():
     console.banner("Retry - Eventual Failure")
     child = py_trees.behaviours.StatusQueue(
         name="R-F-F",
-        sequence=[
+        queue=[
             py_trees.common.Status.RUNNING,
             py_trees.common.Status.FAILURE,
             py_trees.common.Status.FAILURE

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -74,8 +74,8 @@ def test_with_memory_priority_handling():
     child_1 = py_trees.behaviours.Failure("Failure")
     child_2 = py_trees.behaviours.StatusQueue(
         name="Run-Fail",
-        sequence=[py_trees.common.Status.RUNNING,
-                  py_trees.common.Status.FAILURE],
+        queue=[py_trees.common.Status.RUNNING,
+               py_trees.common.Status.FAILURE],
         eventually=None
         )
     child_3 = py_trees.behaviours.Success(name="Success")

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -74,8 +74,8 @@ def test_running_with_no_memory_invalidate_dangling_runners():
     root = py_trees.composites.Sequence(name="Sequence w/o Memory", memory=False)
     child_1 = py_trees.behaviours.StatusQueue(
         name="Success-Running",
-        sequence=[py_trees.common.Status.SUCCESS,
-                  py_trees.common.Status.RUNNING],
+        queue=[py_trees.common.Status.SUCCESS,
+               py_trees.common.Status.RUNNING],
         eventually=None
     )
     child_2 = py_trees.behaviours.Running('Running')
@@ -113,8 +113,8 @@ def test_running_with_memory_proceeds():
     child_1 = py_trees.behaviours.Success(name="Success")
     child_2 = py_trees.behaviours.StatusQueue(
         name="R-S",
-        sequence=[py_trees.common.Status.RUNNING,
-                  py_trees.common.Status.SUCCESS],
+        queue=[py_trees.common.Status.RUNNING,
+               py_trees.common.Status.SUCCESS],
         eventually=None
         )
     child_3 = py_trees.behaviours.Running(name="Running")

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -41,6 +41,9 @@ class SleepInSetup(py_trees.behaviour.Behaviour):
             self.__class__.__name__, self.name, time.time()))
         time.sleep(self.duration)
 
+    def update(self):
+        return py_trees.common.Status.INVALID
+
 
 class SetupVisitor(py_trees.visitors.VisitorBase):
     """

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -34,8 +34,9 @@ def test_valid_filenames():
 def test_get_fully_qualified_name():
     console.banner("Fully Qualified Names")
     pairs = {
-        "py_trees.behaviour.Behaviour": py_trees.behaviour.Behaviour(),
-        "py_trees.decorators.Inverter": py_trees.decorators.Inverter(child=py_trees.behaviours.Success())
+        "py_trees.behaviours.Periodic": py_trees.behaviours.Periodic(name="foo", n=3),
+        "py_trees.decorators.Inverter": py_trees.decorators.Inverter(child=py_trees.behaviours.Success()),
+        "py_trees.behaviours.Success": py_trees.behaviours.Success(),
     }
     print(console.green + "------------------ Assertions ------------------\n" + console.reset)
     for expected_name, object_instance in pairs.items():


### PR DESCRIPTION
Resolves #224.

Also clamps down on use of `update()` for composites. Relates to #268.