### PR TITLE
[display] render exclusive write arrows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Forthcoming
 * [display] bugfix unicode use when no unicode for dot `#359 <https://github.com/splintered-reality/py_trees/pull/359>`_
 * [tests] use tox, flake8 in prem-merge `#354 <https://github.com/splintered-reality/py_trees/pull/354>`_
 * [tests] switch from deprecating nose to pytest, `#350 <https://github.com/splintered-reality/py_trees/pull/350>`_
-* [display] render exclusive write arrows, ``_
+* [display] render exclusive write arrows, `https://github.com/splintered-reality/py_trees/pull/381`_
 
 2.1.6 (2021-05-31)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Forthcoming
 * [display] bugfix unicode use when no unicode for dot `#359 <https://github.com/splintered-reality/py_trees/pull/359>`_
 * [tests] use tox, flake8 in prem-merge `#354 <https://github.com/splintered-reality/py_trees/pull/354>`_
 * [tests] switch from deprecating nose to pytest, `#350 <https://github.com/splintered-reality/py_trees/pull/350>`_
+* [display] render exclusive write arrows, ``_
 
 2.1.6 (2021-05-31)
 ------------------

--- a/py_trees/display.py
+++ b/py_trees/display.py
@@ -643,6 +643,24 @@ def dot_tree(
                         weight=0,
                     )
                 graph.add_edge(edge)
+            for unique_identifier in metadata[key].exclusive:
+                try:
+                    edge = pydot.Edge(
+                        blackboard_id_name_map[unique_identifier],
+                        blackboard_node,
+                        color=blackboard_colour,
+                        constraint=False,
+                        weight=0,
+                    )
+                except KeyError:
+                    edge = pydot.Edge(
+                        clients[unique_identifier].__getattribute__("name"),
+                        blackboard_node,
+                        color=blackboard_colour,
+                        constraint=False,
+                        weight=0,
+                    )
+                graph.add_edge(edge)
         graph.add_subgraph(subgraph)
 
     if with_blackboard_variables:


### PR DESCRIPTION
## Description
I noticed that exclusive write arrows weren't being rendered when using the `render_dot_tree` function.

In the code that adds edges, we check reads and writes, but not exclusive writes.

Adding exclusive writes fixed the issue.

## Open questions
* What color should exclusive writes be? Read is green, write is blue. Any other visual differences we'd prefer?
* Per the [contribution guide](https://github.com/splintered-reality/py_trees/blob/7135c0680dcec886906972e9e2c36b71f667a94d/CONTRIBUTING.md), I was hoping to add labels to this PR, but don't seem to have permissions. Anything I'm doing wrong here?