### PR TITLE
[display] bugfix off-the-grid bb nodes and render exclusive write edges

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Release Notes
 
 Forthcoming
 -----------
+* [display] bugfix off-the-grid bb nodes and render exclusive write edges, `https://github.com/splintered-reality/py_trees/pull/383`_
+* [tests] it's mypy now, by the time this ends, it'll be someone else's py , `https://github.com/splintered-reality/py_trees/pull/380`_
 * [behaviours, decorators] behaviours.Count -> behaviours.StatusQueue + decorators.Count (new), `#376 <https://github.com/splintered-reality/py_trees/pull/376>`_
 * [behaviours, decorators, composites] abstract base classes, `#375 <https://github.com/splintered-reality/py_trees/pull/375>`_
 * [behaviours] StatusSequence -> StatusQueue, `#372 <https://github.com/splintered-reality/py_trees/pull/372>`_

--- a/py_trees/demos/blackboard.py
+++ b/py_trees/demos/blackboard.py
@@ -208,7 +208,7 @@ def main() -> None:
     py_trees.blackboard.Blackboard.enable_activity_stream(maximum_size=100)
     blackboard = py_trees.blackboard.Client(name="Configuration")
     blackboard.register_key(key="dude", access=py_trees.common.Access.WRITE)
-    blackboard.register_key(key="/parameters/default_speed", access=py_trees.common.Access.WRITE)
+    blackboard.register_key(key="/parameters/default_speed", access=py_trees.common.Access.EXCLUSIVE_WRITE)
     blackboard.dude = "Bob"
     blackboard.parameters.default_speed = 30.0
 

--- a/py_trees/display.py
+++ b/py_trees/display.py
@@ -582,7 +582,6 @@ def dot_tree(
             label="Blackboard",
             rank="sink",
         )
-
         for unique_identifier, client_name in clients.items():
             if unique_identifier not in blackboard_id_name_map:
                 subgraph.add_node(
@@ -619,7 +618,7 @@ def dot_tree(
                 except KeyError:
                     edge = pydot.Edge(
                         blackboard_node,
-                        clients[unique_identifier].__getattribute__("name"),
+                        clients[unique_identifier],
                         color="green",
                         constraint=False,
                         weight=0,
@@ -636,9 +635,27 @@ def dot_tree(
                     )
                 except KeyError:
                     edge = pydot.Edge(
-                        clients[unique_identifier].__getattribute__("name"),
+                        clients[unique_identifier],
                         blackboard_node,
                         color=blackboard_colour,
+                        constraint=False,
+                        weight=0,
+                    )
+                graph.add_edge(edge)
+            for unique_identifier in metadata[key].exclusive:
+                try:
+                    edge = pydot.Edge(
+                        blackboard_id_name_map[unique_identifier],
+                        blackboard_node,
+                        color="deepskyblue",
+                        constraint=False,
+                        weight=0,
+                    )
+                except KeyError:
+                    edge = pydot.Edge(
+                        clients[unique_identifier],
+                        blackboard_node,
+                        color="deepskyblue",
                         constraint=False,
                         weight=0,
                     )


### PR DESCRIPTION
Demo with `py-trees-demo-blackboard --render-with-blackboard-variables`.

Followon from #381 (looks like github isn't letting you push commits into forks any longer?).