### PR TITLE
[common] generics, not Any for ComparisonExpression.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Release Notes
 
 Forthcoming
 -----------
+* [common] remove viral ramifications of Any from ComparisonExpression, `https://github.com/splintered-reality/py_trees/pull/386`_
 * [display] bugfix off-the-grid bb nodes and render exclusive write edges, `https://github.com/splintered-reality/py_trees/pull/383`_
 * [tests] it's mypy now, by the time this ends, it'll be someone else's py , `https://github.com/splintered-reality/py_trees/pull/380`_
 * [behaviours, decorators] behaviours.Count -> behaviours.StatusQueue + decorators.Count (new), `#376 <https://github.com/splintered-reality/py_trees/pull/376>`_

--- a/py_trees/common.py
+++ b/py_trees/common.py
@@ -188,6 +188,20 @@ class ClearingPolicy(enum.IntEnum):
 ##############################################################################
 
 
+# TODO: There might be a case for allowing some widening of the arguments,
+# i.e. for left and right hand argument types to the ComparisonExpression
+# operator to vary and/or be covariant / contravariant so different classes
+# or base/derived variants can be compared.
+#
+# To do so however, starts to make the machinery awkward (e.g. forcing
+# the user to only use the 'value' as a right-hand argument to the operator.
+# If this is necessary, a different construct would be better.
+#
+# NB: Widening all the way to Any results in virally plaguing downstream
+# with the ramifications of Any (e.g. any-return).
+ComparisonV = typing.TypeVar('ComparisonV')
+
+
 class ComparisonExpression(object):
     """
     Store the parameters for a univariate comparison operation.
@@ -202,13 +216,23 @@ class ComparisonExpression(object):
 
     .. tip::
         The python `operator module`_ includes many useful comparison operations, e.g. operator.ne
+
+    .. code::
+        import operator
+
+        check = ComparisonExpression(
+            variable="foo",
+            value= 5,
+            operator=operator.eq
+        )
+        success = check.operator(blackboard[check.variable], check.value)
     """
 
     def __init__(
         self,
         variable: str,
-        value: typing.Any,
-        operator: typing.Callable[[typing.Any, typing.Any], bool]
+        value: ComparisonV,
+        operator: typing.Callable[[ComparisonV, ComparisonV], bool]
     ):
         self.variable = variable
         self.value = value


### PR DESCRIPTION
Relates to #336.

Not entirely happy with this, but at least it removes the viral ramifications of `Any`.

**One or Two Generics?**

NB: if using both `T` and `V`:

```
    def __init__(
        self,
        variable: str,
        value: T,
        operator: typing.Callable[[T, V], bool]
    ):
```

this starts to get awkward. The user then must always place the `value` in the right hand side of the operator when checking. This is somewhat arbitrary.

If this is needed, we should rethink the way ComparisonExpression is handled (perhaps provide a method that facilitates this).

**Covariant/Contravariant?**

Certainly could be useful to widen the generics in this way. However, both ways make sense? Ultimately it depends on what the user's base and derived classes look like. There might be some common patterns with standard data structures that could be usefully accommodated though. However, since that is not known at this point, this PR is not making a decision on it yet.