### PR TITLE
[docs] typehints

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,9 @@ extensions = [
 # Extensions Configuration
 ################################################################################
 
+# 'signature', 'description' or 'both'
+autodoc_typehints = "both"
+
 # If true, use the :ivar: role for instance variables, else .. attribute::.
 napoleon_use_ivar = True
 
@@ -86,7 +89,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []
 
 # If true, “(C) Copyright …” is shown in the HTML footer. Default is True.
 html_show_copyright = False


### PR DESCRIPTION
Previously wasn't printing typehints in the parameter fields section of the docs.