### PR TITLE
[composites] use typing.Sequence for children argument

### DIFF
--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -83,7 +83,7 @@ class Composite(behaviour.Behaviour, abc.ABC):
     def __init__(
         self,
         name: str,
-        children: typing.Optional[typing.List[behaviour.Behaviour]] = None,
+        children: typing.Optional[typing.Sequence[behaviour.Behaviour]] = None,
     ):
         super(Composite, self).__init__(name)
         if children is not None:
@@ -381,7 +381,7 @@ class Selector(Composite):
         self,
         name: str,
         memory: bool,
-        children: typing.Optional[typing.List[behaviour.Behaviour]] = None,
+        children: typing.Optional[typing.Sequence[behaviour.Behaviour]] = None,
     ):
         super(Selector, self).__init__(name, children)
         self.memory = memory
@@ -517,7 +517,7 @@ class Sequence(Composite):
         self,
         name: str,
         memory: bool,
-        children: typing.Optional[typing.List[behaviour.Behaviour]] = None,
+        children: typing.Optional[typing.Sequence[behaviour.Behaviour]] = None,
     ):
         super(Sequence, self).__init__(name, children)
         self.memory = memory
@@ -647,7 +647,7 @@ class Parallel(Composite):
         self,
         name: str,
         policy: common.ParallelPolicy.Base,
-        children: typing.Optional[typing.List[behaviour.Behaviour]] = None,
+        children: typing.Optional[typing.Sequence[behaviour.Behaviour]] = None,
     ):
         """
         Initialise the behaviour with name, policy and a list of children.


### PR DESCRIPTION
The Python type system considers `typing.List` to be mutable, and thus invariant on its child type. This doesn't let us pass `Behaviour` subclasses to composites through the `children` parameter, forcing the use of `composite.add_child(child)` or the use of `typing.cast`. Since the `children` list is never mutated, it's better to use `typing.Sequence` here which is covariant and therefore typechecks when a list of `Behaviour` subclasses are passed in.