### PR TITLE
[composites] Reduce circulation when the parallel node policy is SuccessOnOne

### DIFF
--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -731,8 +731,7 @@ class Parallel(Composite):
                     new_status = common.Status.SUCCESS
                     self.current_child = self.children[-1]
             elif type(self.policy) is common.ParallelPolicy.SuccessOnOne:
-                for index in range(len(self.children) - 1, -1, -1):
-                    child = self.children[index]
+                for child in reversed(self.children):
                     if child.status == common.Status.SUCCESS:
                         new_status = common.Status.SUCCESS
                         self.current_child = child

--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -731,14 +731,12 @@ class Parallel(Composite):
                     new_status = common.Status.SUCCESS
                     self.current_child = self.children[-1]
             elif type(self.policy) is common.ParallelPolicy.SuccessOnOne:
-                successful = [
-                    child
-                    for child in self.children
-                    if child.status == common.Status.SUCCESS
-                ]
-                if successful:
-                    new_status = common.Status.SUCCESS
-                    self.current_child = successful[-1]
+                for index in range(len(self.children) - 1, -1, -1):
+                    child = self.children[index]
+                    if child.status == common.Status.SUCCESS:
+                        new_status = common.Status.SUCCESS
+                        self.current_child = child
+                        break
             elif type(self.policy) is common.ParallelPolicy.SuccessOnSelected:
                 if all(
                     [c.status == common.Status.SUCCESS for c in self.policy.children]


### PR DESCRIPTION
motivation: reduce circulation when the parallel node policy is SuccessOnOne

Update: Iterate in reverse order, updating `new_status` and `self.current_child` when the first child whose status is`common.Status.SUCCESS` is found, then terminating the loop
