### PR TITLE
BLD: remove py package, no longer needed for pytest-benchmark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ keywords=["py_trees", "py-trees", "behaviour-trees"]
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 pydot = ">=1.4"
-py = "^1.11.0"
 
 [tool.poetry.group.dev.dependencies]
 tox = ">=3.26"


### PR DESCRIPTION
Fixes #465 

`py` package is no longer necessary to support `pytest`.  It should also not be a core dependency, but if desired I think it can live on as a dev-dependency

This helps avoid [PYSEC-2022-42969](https://osv.dev/vulnerability/PYSEC-2022-42969);