### PR TITLE
Use `typing.Any` for type hints in `kwargs`

### DIFF
--- a/py_trees/composites.py
+++ b/py_trees/composites.py
@@ -660,7 +660,7 @@ class Parallel(Composite):
         super(Parallel, self).__init__(name, children)
         self.policy = policy
 
-    def setup(self, **kwargs: int) -> None:
+    def setup(self, **kwargs: typing.Any) -> None:
         """
         Detect before ticking whether the policy configuration is invalid.
 

--- a/py_trees/decorators.py
+++ b/py_trees/decorators.py
@@ -560,7 +560,7 @@ class Count(Decorator):
         self.running_count = 0
         self.interrupt_count = 0
 
-    def setup(self, **kwargs: int) -> None:
+    def setup(self, **kwargs: typing.Any) -> None:
         """Reset the counters."""
         self.total_tick_count = 0
         self.failure_count = 0

--- a/py_trees/demos/action.py
+++ b/py_trees/demos/action.py
@@ -144,7 +144,7 @@ class Action(py_trees.behaviour.Behaviour):
         super(Action, self).__init__(name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
-    def setup(self, **kwargs: int) -> None:
+    def setup(self, **kwargs: typing.Any) -> None:
         """Kickstart the separate process this behaviour will work with.
 
         Ordinarily this process will be already running. In this case,

--- a/py_trees/demos/lifecycle.py
+++ b/py_trees/demos/lifecycle.py
@@ -107,7 +107,7 @@ class Counter(py_trees.behaviour.Behaviour):
         super(Counter, self).__init__(name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
-    def setup(self, **kwargs: int) -> None:
+    def setup(self, **kwargs: typing.Any) -> None:
         """No delayed initialisation required for this example."""
         self.logger.debug("%s.setup()" % (self.__class__.__name__))
 

--- a/py_trees/trees.py
+++ b/py_trees/trees.py
@@ -51,7 +51,7 @@ def setup(
     root: behaviour.Behaviour,
     timeout: typing.Union[float, common.Duration] = common.Duration.INFINITE,
     visitor: typing.Optional[visitors.VisitorBase] = None,
-    **kwargs: int,
+    **kwargs: typing.Any,
 ) -> None:
     """
     Crawl across a (sub)tree of behaviours calling :meth:`~py_trees.behaviour.Behaviour.setup` on each behaviour.
@@ -355,7 +355,7 @@ class BehaviourTree(object):
         self,
         timeout: typing.Union[float, common.Duration] = common.Duration.INFINITE,
         visitor: typing.Optional[visitors.VisitorBase] = None,
-        **kwargs: int,
+        **kwargs: typing.Any,
     ) -> None:
         """
         Crawl across the tree calling :meth:`~py_trees.behaviour.Behaviour.setup` on each behaviour.


### PR DESCRIPTION
Closes #473 