### PR TITLE
Add auto registration of PortsMixin classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,6 @@ Release Notes
 
 Forthcoming
 -----------
-* [ports] Auto-register ``PortsMixin`` subclasses for the XML parser; ``init_lookup`` is now optional
-* [ports] Add ``register_ports_class()`` / ``get_ports_registry()`` and ``parse_behaviour_tree_xml(..., auto_register=True)``
 
 2.4.0 (2025-11-13)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+Forthcoming
+-----------
+* [ports] Auto-register ``PortsMixin`` subclasses for the XML parser; ``init_lookup`` is now optional
+* [ports] Add ``register_ports_class()`` / ``get_ports_registry()`` and ``parse_behaviour_tree_xml(..., auto_register=True)``
+
 2.4.0 (2025-11-13)
 ------------------
 * [code] Replace type checks with instance checks (`#479 <https://github.com/splintered-reality/py_trees/issues/479>`_)

--- a/docs/ports.rst
+++ b/docs/ports.rst
@@ -126,69 +126,63 @@ Resolving node classes
 
 An XML tag like ``<MyNode>`` is just a name --- before the parser can build the node it has
 to find the Python class that name refers to. This section explains how that lookup happens
-and how you can steer it.
+and how you can customize it.
 
-By default it is automatic: every concrete :class:`~py_trees.ports.PortsMixin` subclass
+There is a ``node_registry`` argument which controls that lookup, and takes one of two forms.
+
+**1. Auto (the default).** Every concrete :class:`~py_trees.ports.PortsMixin` subclass
 registers itself (under its class name) the moment it is defined. So as long as your node
-classes have been imported, the parser can find them by tag with no extra configuration.
+classes have been imported, the parser resolves every tag with no extra configuration ---
+``node_registry="auto"`` is the default, so you pass nothing:
 
-For the cases automatic lookup can't handle on its own, the parser also accepts an
-``init_lookup`` argument --- a plain ``{tag: class}`` dictionary you pass in explicitly.
-Reach for it when you want to
+.. code-block:: python
 
-* construct a node with extra arguments (e.g. inject a dependency via ``functools.partial``),
-* expose a class under a tag other than its class name (aliasing), or
-* bypass the automatic registry entirely and stay fully explicit.
+   from py_trees.parsers.behaviour_tree_xml import parse_behaviour_tree_xml
+   from my_nodes import MyNode, OtherNode  # importing is enough to register them
 
-When both are present they are merged, with ``init_lookup`` winning on conflicts::
+   root = parse_behaviour_tree_xml("my_tree.xml")
 
-    lookup = (auto-registered PortsMixin classes) | (init_lookup or {})
+**2. An explicit dict.** Pass a ``{tag: class-or-callable}`` mapping to use *exactly* that
+mapping and ignore the auto-registry. This is the form to reach for when you need to inject
+a dependency, alias a tag, or sandbox the parser to a fixed set of classes:
 
-In practice this comes down to four usage patterns:
+.. code-block:: python
 
-1. **Auto-only** --- define your :class:`~py_trees.ports.PortsMixin` subclasses, import them,
-   and parse:
+   root = parse_behaviour_tree_xml(
+       "my_tree.xml",
+       node_registry={"MyNode": MyNode, "OtherNode": OtherNode},  # only these, no auto
+   )
 
-   .. code-block:: python
+To **combine** auto-registration with a few explicit entries --- most commonly to inject a
+runtime dependency via ``functools.partial`` (a partial isn't a class, so it can't live in
+the auto-registry) --- spread the auto-registry into your dict and override the entries you
+need:
 
-      from py_trees.parsers.behaviour_tree_xml import parse_behaviour_tree_xml
-      from my_nodes import MyNode, OtherNode  # importing is enough to register them
+.. code-block:: python
 
-      root = parse_behaviour_tree_xml("my_tree.xml")
+   import py_trees
+   from functools import partial
 
-2. **Auto + partial injection** --- auto-registration handles the class lookup while
-   ``init_lookup`` injects runtime dependencies:
+   root = parse_behaviour_tree_xml(
+       "my_tree.xml",
+       node_registry={
+           **py_trees.ports.get_ports_registry(),       # everything auto-registered, plus...
+           "Wait": partial(Wait, factory=my_factory),   # ...a dependency-injected override
+       },
+   )
 
-   .. code-block:: python
+**Aliasing.** To expose a class under an extra tag, register it under that tag --- either
+inline on the class definition or via the helper for classes you cannot modify. Either way it
+then resolves under the alias in the ``"auto"`` path:
 
-      from functools import partial
+.. code-block:: python
 
-      root = parse_behaviour_tree_xml(
-          "my_tree.xml",
-          init_lookup={"Wait": partial(Wait, factory=my_factory)},
-      )
+   class Foo(PortsMixin, py_trees.behaviour.Behaviour, tag="Bar"):
+       ...
 
-3. **Aliasing** --- register a class under an extra tag, either inline on the class
-   definition or via the helper for classes you cannot modify:
-
-   .. code-block:: python
-
-      class Foo(PortsMixin, py_trees.behaviour.Behaviour, tag="Bar"):
-          ...
-
-      # or, for a third-party class:
-      from py_trees.ports import register_ports_class
-      register_ports_class("Bar", Foo)
-
-4. **Fully explicit** --- opt out of the registry entirely (strict / sandboxed):
-
-   .. code-block:: python
-
-      root = parse_behaviour_tree_xml(
-          "my_tree.xml",
-          init_lookup={"MyNode": MyNode, "OtherNode": OtherNode},
-          auto_register=False,
-      )
+   # or, for a third-party class:
+   from py_trees.ports import register_ports_class
+   register_ports_class("Bar", Foo)
 
 Pass ``register=False`` on a class definition to keep a particular subclass out of the
 registry. Still-abstract classes (e.g. :class:`~py_trees.ports.BehaviourWithPorts` itself,
@@ -260,7 +254,7 @@ A few things you should be aware of, and suggestions on how to fill the gaps you
    For example, ``<Parallel synchronise="true">`` has no effect, and port-style attributes on these tags are dropped without warning.
    This is also why you cannot take the number of attempts for a :class:`py_trees.decorators.Retry` from a port value via XML ---
    the parser only wires ports (and forwards constructor kwargs; see :ref:`ports-xml-attributes-label` above) on resolved classes that derive from
-   :class:`~py_trees.ports.PortsMixin` (whether auto-registered or supplied via ``init_lookup``; see :ref:`ports-xml-class-resolution-label` above).
+   :class:`~py_trees.ports.PortsMixin` (whether resolved via the ``"auto"`` registry or an explicit ``node_registry`` dict; see :ref:`ports-xml-class-resolution-label` above).
    Built-in decorators aren't recognised as XML tags at all.
 
 **3. The pattern: port-aware wrapper classes.**

--- a/docs/ports.rst
+++ b/docs/ports.rst
@@ -113,12 +113,86 @@ It builds a py_trees tree from an XML file and auto-generates the port remapping
 
    from py_trees.parsers.behaviour_tree_xml import parse_behaviour_tree_xml
 
-   root = parse_behaviour_tree_xml(
-       "my_tree.xml",
-       init_lookup={"MyNode": MyNode, "OtherNode": OtherNode, ...},
-   )
+   root = parse_behaviour_tree_xml("my_tree.xml")
 
-See the :ref:`demos <ports-demos-section-label>` below for working examples.
+How the parser maps each XML tag to a Python class is covered in
+:ref:`Resolving node classes <ports-xml-class-resolution-label>` just below.
+The :ref:`demos <ports-demos-section-label>` further down show complete working examples.
+
+.. _ports-xml-class-resolution-label:
+
+Resolving node classes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+An XML tag like ``<MyNode>`` is just a name --- before the parser can build the node it has
+to find the Python class that name refers to. This section explains how that lookup happens
+and how you can steer it.
+
+By default it is automatic: every concrete :class:`~py_trees.ports.PortsMixin` subclass
+registers itself (under its class name) the moment it is defined. So as long as your node
+classes have been imported, the parser can find them by tag with no extra configuration.
+
+For the cases automatic lookup can't handle on its own, the parser also accepts an
+``init_lookup`` argument --- a plain ``{tag: class}`` dictionary you pass in explicitly.
+Reach for it when you want to
+
+* construct a node with extra arguments (e.g. inject a dependency via ``functools.partial``),
+* expose a class under a tag other than its class name (aliasing), or
+* bypass the automatic registry entirely and stay fully explicit.
+
+When both are present they are merged, with ``init_lookup`` winning on conflicts::
+
+    lookup = (auto-registered PortsMixin classes) | (init_lookup or {})
+
+In practice this comes down to four usage patterns:
+
+1. **Auto-only** --- define your :class:`~py_trees.ports.PortsMixin` subclasses, import them,
+   and parse:
+
+   .. code-block:: python
+
+      from py_trees.parsers.behaviour_tree_xml import parse_behaviour_tree_xml
+      from my_nodes import MyNode, OtherNode  # importing is enough to register them
+
+      root = parse_behaviour_tree_xml("my_tree.xml")
+
+2. **Auto + partial injection** --- auto-registration handles the class lookup while
+   ``init_lookup`` injects runtime dependencies:
+
+   .. code-block:: python
+
+      from functools import partial
+
+      root = parse_behaviour_tree_xml(
+          "my_tree.xml",
+          init_lookup={"Wait": partial(Wait, factory=my_factory)},
+      )
+
+3. **Aliasing** --- register a class under an extra tag, either inline on the class
+   definition or via the helper for classes you cannot modify:
+
+   .. code-block:: python
+
+      class Foo(PortsMixin, py_trees.behaviour.Behaviour, tag="Bar"):
+          ...
+
+      # or, for a third-party class:
+      from py_trees.ports import register_ports_class
+      register_ports_class("Bar", Foo)
+
+4. **Fully explicit** --- opt out of the registry entirely (strict / sandboxed):
+
+   .. code-block:: python
+
+      root = parse_behaviour_tree_xml(
+          "my_tree.xml",
+          init_lookup={"MyNode": MyNode, "OtherNode": OtherNode},
+          auto_register=False,
+      )
+
+Pass ``register=False`` on a class definition to keep a particular subclass out of the
+registry. Still-abstract classes (e.g. :class:`~py_trees.ports.BehaviourWithPorts` itself,
+which does not implement ``input_ports`` / ``output_ports``) are never registered.
 
 .. _ports-xml-attributes-label:
 
@@ -184,7 +258,9 @@ A few things you should be aware of, and suggestions on how to fill the gaps you
 
    **Any other attribute on a built-in composite tag is silently ignored.**
    For example, ``<Parallel synchronise="true">`` has no effect, and port-style attributes on these tags are dropped without warning.
-   This is also why you cannot take the number of attempts for a :class:`py_trees.decorators.Retry` from a port value via XML --- the parser only wires ports (and forwards constructor kwargs; see :ref:`ports-xml-attributes-label` above) on classes registered in ``init_lookup`` that derive from :class:`~py_trees.ports.PortsMixin`.
+   This is also why you cannot take the number of attempts for a :class:`py_trees.decorators.Retry` from a port value via XML ---
+   the parser only wires ports (and forwards constructor kwargs; see :ref:`ports-xml-attributes-label` above) on resolved classes that derive from
+   :class:`~py_trees.ports.PortsMixin` (whether auto-registered or supplied via ``init_lookup``; see :ref:`ports-xml-class-resolution-label` above).
    Built-in decorators aren't recognised as XML tags at all.
 
 **3. The pattern: port-aware wrapper classes.**

--- a/py_trees/demos/ports/nested_subtrees.py
+++ b/py_trees/demos/ports/nested_subtrees.py
@@ -108,13 +108,7 @@ def main() -> None:
     py_trees.blackboard.Blackboard.clear()
 
     xml_file = Path(__file__).with_name("nested_subtrees.xml")
-    init_lookup = {
-        "StartMissionReport": StartMissionReport,
-        "AddMissionStep": AddMissionStep,
-        "ReadMissionReport": ReadMissionReport,
-    }
-
-    root = parse_behaviour_tree_xml(str(xml_file), init_lookup=init_lookup)
+    root = parse_behaviour_tree_xml(str(xml_file))
     tree = py_trees.trees.BehaviourTree(root)
     tree.tick()
 

--- a/py_trees/demos/ports/xml_tree.py
+++ b/py_trees/demos/ports/xml_tree.py
@@ -103,12 +103,7 @@ def main() -> None:
     py_trees.blackboard.Blackboard.clear()
 
     xml_file = Path(__file__).with_name("xml_tree.xml")
-    init_lookup = {
-        "GreetingProducer": GreetingProducer,
-        "AddSuffix": AddSuffix,
-        "PrintConsumer": PrintConsumer,
-    }
-    root = parse_behaviour_tree_xml(str(xml_file), init_lookup=init_lookup)
+    root = parse_behaviour_tree_xml(str(xml_file))
 
     tree = py_trees.trees.BehaviourTree(root)
     tree.tick()

--- a/py_trees/parsers/behaviour_tree_xml.py
+++ b/py_trees/parsers/behaviour_tree_xml.py
@@ -121,12 +121,7 @@ from typing import Any
 
 import py_trees
 
-from py_trees.ports import (
-    CONST_PREFIX,
-    DOT_REPLACEMENT,
-    get_ports_registry,
-    PortsMixin,
-)
+from py_trees.ports import CONST_PREFIX, DOT_REPLACEMENT, get_ports_registry, PortsMixin
 from py_trees.ports_utils import (
     apply_type_hints,
     generate_node_name,

--- a/py_trees/parsers/behaviour_tree_xml.py
+++ b/py_trees/parsers/behaviour_tree_xml.py
@@ -262,30 +262,28 @@ def get_absolute_reference(value: str, subtree_namespace: str) -> str:
     return subtree_namespace.rstrip("/") + "/" + value
 
 
-def get_class_from_init_lookup(
-    class_name: str, init_lookup: dict
-) -> type["PortsMixin"]:
+def get_class_from_registry(class_name: str, node_registry: dict) -> type["PortsMixin"]:
     """
-    Get the class from the init_lookup dictionary, ensuring it is a subclass of :class:`PortsMixin`.
+    Get the class from the node_registry dictionary, ensuring it is a subclass of :class:`PortsMixin`.
 
     Args:
         class_name (str): The name of the class to look up.
-        init_lookup (dict): A dictionary mapping class names to class constructors or partial callables,
+        node_registry (dict): A dictionary mapping class names to class constructors or partial callables,
             e.g. ``{"Producer": Producer, "Consumer": partial(Consumer, name=name)}``.
 
     Returns:
         The class (subclass of :class:`PortsMixin`).
 
     Raises:
-        KeyError: If the class name is not found in the init_lookup.
+        KeyError: If the class name is not found in the node_registry.
         TypeError: If the entry is not a class or partial callable,
             or if the class is not a subclass of :class:`PortsMixin`.
     """
-    if class_name not in init_lookup:
+    if class_name not in node_registry:
         raise KeyError(
-            f"Class name '{class_name}' not found in init_lookup: {init_lookup}"
+            f"Class name '{class_name}' not found in node_registry: {node_registry}"
         )
-    entry = init_lookup[class_name]
+    entry = node_registry[class_name]
 
     # Case 1: Direct class reference
     if inspect.isclass(entry):
@@ -305,10 +303,9 @@ def get_class_from_init_lookup(
 def parse_behaviour_tree_xml(
     xml_file: str,
     main_tree_id: str | None = None,
-    init_lookup: dict | None = None,
+    node_registry: dict | str = "auto",
     logger: PortsLogger | None = None,
     search_paths: list[str] | None = None,
-    auto_register: bool = True,
 ) -> py_trees.behaviour.Behaviour:
     """
     Parse the XML file and build the behavior tree.
@@ -321,42 +318,57 @@ def parse_behaviour_tree_xml(
     into the current document. If any imported BehaviorTree ID already exists, a
     ValueError is raised.
 
-    Node classes are resolved from two sources, merged in this order::
+    Node classes are resolved from ``node_registry``, which is either:
 
-        lookup = (auto-registered PortsMixin classes) | (init_lookup or {})
+    * ``"auto"`` (the default) --- resolve every XML tag from the global registry of
+      auto-registered :class:`~py_trees.ports.PortsMixin` subclasses. Importing your
+      node classes is enough to make them usable; no explicit mapping is needed.
+    * a ``dict`` mapping tag -> class / callable --- use *exactly* this mapping and
+      ignore the auto-registry. Use this to inject dependencies via
+      ``functools.partial`` (e.g. ``{"Wait": partial(Wait, factory=f)}``), to alias
+      tags, or to sandbox the parser to a fixed set of classes.
 
-    so an explicit ``init_lookup`` entry always overrides an auto-registered
-    class of the same name. Auto-registration (on by default) means any imported
-    :class:`~py_trees.ports.PortsMixin` subclass is usable in XML without an
-    ``init_lookup`` entry; ``init_lookup`` remains useful for ``functools.partial``
-    dependency injection, inline aliasing, and overrides. Set ``auto_register=False``
-    to resolve classes exclusively from ``init_lookup``.
+    To combine auto-registration with a few explicit entries, build the dict on top
+    of the auto-registry::
+
+        node_registry={**py_trees.ports.get_ports_registry(), "Wait": partial(Wait, factory=f)}
 
     Args:
         xml_file (str): Path to the main XML file.
         main_tree_id (str | None): ID of the tree to execute; if None, read from 'main_tree_to_execute'.
-        init_lookup (dict | None): Optional mapping from tag -> constructor/partial for PortsMixin
-            nodes. Overrides auto-registered classes of the same name.
+        node_registry (dict | str): ``"auto"`` to resolve from the auto-registry, or a
+            ``{tag: class/partial}`` dict to use exclusively. Defaults to ``"auto"``.
         logger (PortsLogger | None): Optional logger (NoOp if None).
         search_paths (list[str] | None): Optional extra directories to resolve imports.
-        auto_register (bool): Include auto-registered PortsMixin subclasses in the lookup
-            (default True). Set to False to use only ``init_lookup``.
 
     Returns:
         The root py_trees.behaviour.Behaviour for the requested tree.
 
     Raises:
-        ValueError: If no node classes are available (empty ``init_lookup`` and
-            ``auto_register=False`` or empty registry) or the main BehaviorTree ID is not found.
+        ValueError: If ``node_registry`` is a string other than ``"auto"``, if no node
+            classes are available, or the main BehaviorTree ID is not found.
+        TypeError: If ``node_registry`` is neither a dict nor a string.
         FileNotFoundError / RuntimeError: From the import pre-pass if relevant.
     """
     if logger is None:
         logger = NOOP_LOGGER
-    init_lookup = (get_ports_registry() if auto_register else {}) | (init_lookup or {})
-    if not init_lookup:
+    if isinstance(node_registry, str):
+        if node_registry != "auto":
+            raise ValueError(
+                f"node_registry string must be 'auto', got {node_registry!r}."
+            )
+        node_registry = get_ports_registry()
+    elif isinstance(node_registry, dict):
+        node_registry = dict(node_registry)
+    else:
+        raise TypeError(
+            "node_registry must be a dict (tag -> class/partial) or the string "
+            f"'auto', got {type(node_registry).__name__}."
+        )
+    if not node_registry:
         raise ValueError(
-            "No node classes available to the parser: provide an init_lookup and/or "
-            "define/import PortsMixin subclasses with auto_register=True."
+            "No node classes available to the parser: pass node_registry='auto' "
+            "with your PortsMixin subclasses imported, or an explicit {tag: class} dict."
         )
 
     xml_tree = ET.parse(xml_file)
@@ -385,7 +397,7 @@ def parse_behaviour_tree_xml(
     tree = build_tree_from_xml(
         bt_elem,
         remapping_table={},
-        init_lookup=init_lookup,
+        node_registry=node_registry,
         bt_index=bt_index,
         logger=logger,
         subtree_namespace="/",
@@ -580,7 +592,7 @@ def build_port_remappings(
 
 def instantiate_ports_node(
     elem: ET.Element,
-    init_lookup: dict,
+    node_registry: dict,
     remapping_table: dict[str, str],
     subtree_namespace: str,
     logger: PortsLogger = NOOP_LOGGER,
@@ -590,14 +602,14 @@ def instantiate_ports_node(
     """
     Instantiate any PortsMixin-based node (leaf or composite).
 
-    - looks up the class via `init_lookup` (validated with `get_class_from_init_lookup`)
+    - looks up the class via `node_registry` (validated with `get_class_from_registry`)
     - builds port remappings from `elem.attrib`
     - constructs the instance (using `name` attribute or class_name)
     - calls `setup_ports(...)`
 
     Args:
         elem: The XML element to parse.
-        init_lookup (dict): Mapping from class names (str) to callables (constructors or partials)
+        node_registry (dict): Mapping from class names (str) to callables (constructors or partials)
             that return ``PortsMixin``-derived instances.
         remapping_table (dict): Mapping from keys (str) to absolute keys (str).
         subtree_namespace (str): The namespace for this subtree.
@@ -609,12 +621,12 @@ def instantiate_ports_node(
         PortsMixin: the fully initialised node.
     """
     portsmixin_name = elem.tag
-    # Get the class definition from init_lookup - needed to check the ports.
+    # Get the class definition from node_registry - needed to check the ports.
     try:
-        cls = get_class_from_init_lookup(portsmixin_name, init_lookup)
+        cls = get_class_from_registry(portsmixin_name, node_registry)
     except KeyError:
         raise NotImplementedError(
-            f"Class name '{portsmixin_name}' not found in init_lookup.Supporting other types is still TODO."
+            f"Class name '{portsmixin_name}' not found in node_registry.Supporting other types is still TODO."
         )
 
     port_remappings = build_port_remappings(
@@ -634,9 +646,9 @@ def instantiate_ports_node(
         f"PortsMixin node '{instance_name}' in namespace {subtree_namespace} remappings: {port_remappings}"
     )
 
-    if portsmixin_name not in init_lookup:
+    if portsmixin_name not in node_registry:
         raise ValueError(
-            f"PortsMixin class '{portsmixin_name}' not found in init_lookup table"
+            f"PortsMixin class '{portsmixin_name}' not found in node_registry table"
         )
 
     constructor_kwargs = constructor_kwargs or {}  # create constructor_kwargs
@@ -664,7 +676,7 @@ def instantiate_ports_node(
             )
             constructor_kwargs[attrib_key] = attrib_value
 
-    ctor_callable = init_lookup[portsmixin_name]
+    ctor_callable = node_registry[portsmixin_name]
     # Try to convert the constructor arguments to the correct type.
     ignore_keys = {"child", "children", "behaviour_class_name"}
     constructor_kwargs, success = apply_type_hints(
@@ -677,7 +689,7 @@ def instantiate_ports_node(
         )
     try:
         # Pass the behaviour_class_name (the tag/registry name) to the constructor
-        node: PortsMixin = init_lookup[portsmixin_name](
+        node: PortsMixin = node_registry[portsmixin_name](
             name=instance_name,
             behaviour_class_name=portsmixin_name,
             **constructor_kwargs,
@@ -700,7 +712,7 @@ def instantiate_ports_node(
 def build_tree_from_xml(
     elem: ET.Element,
     remapping_table: dict[str, str],
-    init_lookup: dict,
+    node_registry: dict,
     bt_index: dict,
     logger: PortsLogger = NOOP_LOGGER,
     subtree_namespace: str = "/",
@@ -712,7 +724,7 @@ def build_tree_from_xml(
     Args:
         elem: XML element
         remapping_table (dict[str, str]): Remapping table.
-        init_lookup (dict): Mapping from class names (str) to callables (constructors or partials)
+        node_registry (dict): Mapping from class names (str) to callables (constructors or partials)
             that return ``PortsMixin``-derived instances.
         bt_index (dict[str, BehaviorTree]): dictionary {ID: BehaviorTree element} for subtree lookup.
         subtree_namespace (str): current blackboard namespace.
@@ -757,7 +769,7 @@ def build_tree_from_xml(
             child_node = build_tree_from_xml(
                 child,
                 remapping_table,
-                init_lookup,
+                node_registry,
                 bt_index,
                 logger=logger,
                 subtree_namespace=subtree_namespace,
@@ -796,7 +808,7 @@ def build_tree_from_xml(
         elif tag in PARENT_NODES_WITH_PORTS_TAGS:
             # Instantiate ports-enabled composite
             constructor_kwargs: dict[str, Any] = {}
-            cls = get_class_from_init_lookup(elem.tag, init_lookup)
+            cls = get_class_from_registry(elem.tag, node_registry)
             if issubclass(cls, py_trees.decorators.Decorator):
                 if not len(children) == 1:
                     raise ValueError(
@@ -807,7 +819,7 @@ def build_tree_from_xml(
                 constructor_kwargs["children"] = children
             node = instantiate_ports_node(
                 elem=elem,
-                init_lookup=init_lookup,
+                node_registry=node_registry,
                 remapping_table=remapping_table,
                 subtree_namespace=subtree_namespace,
                 logger=logger,
@@ -845,7 +857,7 @@ def build_tree_from_xml(
         return build_tree_from_xml(
             child_elems[0],
             remapping_table,
-            init_lookup,
+            node_registry,
             bt_index,
             logger=logger,
             subtree_namespace=subtree_namespace,
@@ -875,19 +887,19 @@ def build_tree_from_xml(
         return build_tree_from_xml(
             subtree_elem,
             new_remapping,
-            init_lookup,
+            node_registry,
             bt_index,
             logger=logger,
             subtree_namespace=new_namespace,
             parent_names_str=((parent_names_str + ".") if parent_names_str else "")
             + subtree_name,
         )
-    elif elem.tag in init_lookup:
+    elif elem.tag in node_registry:
         # Leaf PortsMixin node (any PortsMixin + Behaviour combination).
         logger.debug(f"Creating PortsMixin leaf node for tag {elem.tag}.")
         node = instantiate_ports_node(
             elem=elem,
-            init_lookup=init_lookup,
+            node_registry=node_registry,
             remapping_table=remapping_table,
             subtree_namespace=subtree_namespace,
             logger=logger,

--- a/py_trees/parsers/behaviour_tree_xml.py
+++ b/py_trees/parsers/behaviour_tree_xml.py
@@ -121,7 +121,12 @@ from typing import Any
 
 import py_trees
 
-from py_trees.ports import CONST_PREFIX, DOT_REPLACEMENT, PortsMixin
+from py_trees.ports import (
+    CONST_PREFIX,
+    DOT_REPLACEMENT,
+    get_ports_registry,
+    PortsMixin,
+)
 from py_trees.ports_utils import (
     apply_type_hints,
     generate_node_name,
@@ -308,6 +313,7 @@ def parse_behaviour_tree_xml(
     init_lookup: dict | None = None,
     logger: PortsLogger | None = None,
     search_paths: list[str] | None = None,
+    auto_register: bool = True,
 ) -> py_trees.behaviour.Behaviour:
     """
     Parse the XML file and build the behavior tree.
@@ -320,24 +326,43 @@ def parse_behaviour_tree_xml(
     into the current document. If any imported BehaviorTree ID already exists, a
     ValueError is raised.
 
+    Node classes are resolved from two sources, merged in this order::
+
+        lookup = (auto-registered PortsMixin classes) | (init_lookup or {})
+
+    so an explicit ``init_lookup`` entry always overrides an auto-registered
+    class of the same name. Auto-registration (on by default) means any imported
+    :class:`~py_trees.ports.PortsMixin` subclass is usable in XML without an
+    ``init_lookup`` entry; ``init_lookup`` remains useful for ``functools.partial``
+    dependency injection, inline aliasing, and overrides. Set ``auto_register=False``
+    to resolve classes exclusively from ``init_lookup``.
+
     Args:
         xml_file (str): Path to the main XML file.
         main_tree_id (str | None): ID of the tree to execute; if None, read from 'main_tree_to_execute'.
-        init_lookup (dict): Mapping from tag -> constructor/partial for PortsMixin nodes (required).
+        init_lookup (dict | None): Optional mapping from tag -> constructor/partial for PortsMixin
+            nodes. Overrides auto-registered classes of the same name.
         logger (PortsLogger | None): Optional logger (NoOp if None).
         search_paths (list[str] | None): Optional extra directories to resolve imports.
+        auto_register (bool): Include auto-registered PortsMixin subclasses in the lookup
+            (default True). Set to False to use only ``init_lookup``.
 
     Returns:
         The root py_trees.behaviour.Behaviour for the requested tree.
 
     Raises:
-        ValueError: If init_lookup is missing or the main BehaviorTree ID is not found.
+        ValueError: If no node classes are available (empty ``init_lookup`` and
+            ``auto_register=False`` or empty registry) or the main BehaviorTree ID is not found.
         FileNotFoundError / RuntimeError: From the import pre-pass if relevant.
     """
     if logger is None:
         logger = NOOP_LOGGER
-    if init_lookup is None:
-        raise ValueError("init_lookup dictionary must be provided")
+    init_lookup = (get_ports_registry() if auto_register else {}) | (init_lookup or {})
+    if not init_lookup:
+        raise ValueError(
+            "No node classes available to the parser: provide an init_lookup and/or "
+            "define/import PortsMixin subclasses with auto_register=True."
+        )
 
     xml_tree = ET.parse(xml_file)
     root = xml_tree.getroot()

--- a/py_trees/ports.py
+++ b/py_trees/ports.py
@@ -15,6 +15,7 @@
 
 import types
 import typing
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
@@ -40,8 +41,8 @@ if TYPE_CHECKING:
 else:
     _MixinBase = ABC
 
-# Const Prefix for parsing direct values to the XML parser
-# Any entry having this prefix should be interpreted as a direct value (not key) to the XML parser
+# Const Prefix for parsing direct values from a tree parser
+# Any entry having this prefix should be interpreted as a direct value (not key) by a parser
 CONST_PREFIX = "__const_"
 
 # Dots are a problem in strings used as direct values in input ports, because a dot is
@@ -63,6 +64,65 @@ class PortInformation:
     data_type: Any
     required: bool = True
     description: str = ""
+
+
+##############################################################################
+# Class registry for tree parsers
+##############################################################################
+
+# Maps a tag (lookup name) to a concrete PortsMixin subclass. Populated
+# automatically by PortsMixin.__init_subclass__. Defining and importing a
+# PortsMixin subclass is enough to make it resolvable by tag, e.g. from a parser.
+_REGISTRY: dict[str, type["PortsMixin"]] = {}
+
+
+def register_ports_class(tag: str, cls: type) -> None:
+    """
+    Register *cls* under *tag* in the global ports registry.
+
+    Use this to alias a class under an additional tag, or to register a
+    third-party :class:`PortsMixin` subclass that cannot be modified to pass
+    ``tag=`` / ``register=`` at definition time.
+
+    Args:
+        tag: The tag (lookup name) to register under.
+        cls: A concrete subclass of :class:`PortsMixin`.
+
+    Raises:
+        TypeError: If *cls* is not a subclass of :class:`PortsMixin`.
+    """
+    if not (isinstance(cls, type) and issubclass(cls, PortsMixin)):
+        raise TypeError(
+            f"Cannot register '{tag}': {cls!r} is not a PortsMixin subclass."
+        )
+    existing = _REGISTRY.get(tag)
+    if existing is not None and existing is not cls:
+        warnings.warn(
+            f"Ports class tag '{tag}' is already registered to "
+            f"'{existing.__name__}'; overriding with '{cls.__name__}' (last wins).",
+            stacklevel=2,
+        )
+    _REGISTRY[tag] = cls
+
+
+def get_ports_registry() -> dict[str, type["PortsMixin"]]:
+    """Return a shallow copy of the global ports registry (``{tag: class}``)."""
+    return dict(_REGISTRY)
+
+
+def _ports_class_is_abstract(cls: type) -> bool:
+    """
+    Return whether *cls* still has unimplemented abstract methods.
+
+    This intentionally scans the resolved attributes rather than reading
+    ``cls.__abstractmethods__``: ``__init_subclass__`` runs *before* ``ABCMeta``
+    populates ``__abstractmethods__`` on the new class, so that attribute is not
+    yet reliable at registration time.
+    """
+    return any(
+        getattr(getattr(cls, name, None), "__isabstractmethod__", False)
+        for name in dir(cls)
+    )
 
 
 class PortsMixin(_MixinBase):
@@ -143,7 +203,7 @@ class PortsMixin(_MixinBase):
 
     **Blackboard namespace strategy**
 
-    When a port is **not** explicitly remapped (via XML or constructor arguments), a dedicated storage key
+    When a port is **not** explicitly remapped (via a remapping table or constructor arguments), a dedicated storage key
     is generated, so that sibling nodes with the same port name do not accidentally share data. This
     "synthesised" key is derived from:
 
@@ -193,6 +253,28 @@ class PortsMixin(_MixinBase):
                 self._set_output("output", f"Processed({input_val})")
                 return py_trees.common.Status.SUCCESS
     """
+
+    def __init_subclass__(
+        cls, *, tag: str | None = None, register: bool = True, **kwargs: Any
+    ) -> None:
+        """
+        Auto-register concrete subclasses so parsers can resolve them by tag.
+
+        Defining a concrete ``PortsMixin`` subclass registers it under its class
+        name (or *tag*, if given) in the global ports registry, so a parser can
+        resolve it by tag.
+
+        Args:
+            tag: Optional explicit tag (lookup name). Defaults to ``cls.__name__``.
+            register: Set to ``False`` to skip auto-registration for this class.
+
+        Still-abstract subclasses (e.g. :class:`BehaviourWithPorts`, which does
+        not implement ``input_ports`` / ``output_ports``) are never registered.
+        """
+        super().__init_subclass__(**kwargs)
+        if not register or _ports_class_is_abstract(cls):
+            return
+        register_ports_class(tag if tag is not None else cls.__name__, cls)
 
     @classmethod
     @abstractmethod
@@ -256,7 +338,7 @@ class PortsMixin(_MixinBase):
             *args: Positional arguments passed to the parent class (typically py_trees.behaviour.Behaviour).
             behaviour_class_name: The name under which this behavior class is registered (e.g., in a registry).
                 Typically corresponds to the class name itself, but can also be an alias
-                for partial instantiations or custom registrations (with XML parsing, this would be the XML tag name).
+                for partial instantiations or custom registrations (with a tree parser, this would be the tag name).
                 If None, defaults to the actual class name (self.__class__.__name__).
             **kwargs: Additional keyword arguments passed to the parent class.
 

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -12,7 +12,12 @@ import unittest
 
 import py_trees
 
-from py_trees.ports import NoDataAvailable
+from py_trees.ports import (
+    BehaviourWithPorts,
+    get_ports_registry,
+    NoDataAvailable,
+    register_ports_class,
+)
 
 from .test_ports_helpers import Consumer, ConsumerProducer, Producer
 
@@ -274,6 +279,62 @@ class TestBehaviourWithPorts(unittest.TestCase):
 
         prod._set_output("output", "wired")
         self.assertEqual(cons.get_input("input"), "wired")
+
+
+class TestPortsClassRegistry(unittest.TestCase):
+    """Auto-registration of PortsMixin subclasses for the XML parser."""
+
+    @staticmethod
+    def _make_leaf(**clskwargs: object) -> type:
+        class _Leaf(BehaviourWithPorts, **clskwargs):  # type: ignore[misc]
+            @classmethod
+            def input_ports(cls) -> dict:
+                return {}
+
+            @classmethod
+            def output_ports(cls) -> dict:
+                return {}
+
+            def update(self) -> py_trees.common.Status:
+                return py_trees.common.Status.SUCCESS
+
+        return _Leaf
+
+    def test_concrete_subclass_is_registered(self) -> None:
+        # Producer is a concrete BehaviourWithPorts imported by the test helpers.
+        self.assertIs(get_ports_registry().get("Producer"), Producer)
+
+    def test_abstract_bases_are_not_registered(self) -> None:
+        # Neither the mixin nor the still-abstract convenience base is registered.
+        registry = get_ports_registry()
+        self.assertNotIn("PortsMixin", registry)
+        self.assertNotIn("BehaviourWithPorts", registry)
+
+    def test_tag_alias_at_definition(self) -> None:
+        leaf = self._make_leaf(tag="AliasTag")
+        registry = get_ports_registry()
+        self.assertIs(registry.get("AliasTag"), leaf)
+        self.assertNotIn(leaf.__name__, registry)
+
+    def test_register_false_opts_out(self) -> None:
+        leaf = self._make_leaf(register=False)
+        self.assertNotIn(leaf.__name__, get_ports_registry())
+
+    def test_register_ports_class_aliases(self) -> None:
+        register_ports_class("ProducerAlias", Producer)
+        self.assertIs(get_ports_registry().get("ProducerAlias"), Producer)
+
+    def test_register_ports_class_rejects_non_portsmixin(self) -> None:
+        with self.assertRaises(TypeError):
+            register_ports_class("NotAPort", py_trees.behaviour.Behaviour)
+
+    def test_duplicate_name_warns_and_last_wins(self) -> None:
+        first = self._make_leaf(register=False)
+        second = self._make_leaf(register=False)
+        register_ports_class("DupTag", first)
+        with self.assertWarns(UserWarning):
+            register_ports_class("DupTag", second)
+        self.assertIs(get_ports_registry().get("DupTag"), second)
 
 
 if __name__ == "__main__":

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -281,24 +281,23 @@ class TestBehaviourWithPorts(unittest.TestCase):
         self.assertEqual(cons.get_input("input"), "wired")
 
 
+class _RegistryLeaf(BehaviourWithPorts, register=False):
+    """Concrete leaf used to exercise the registry; itself kept out of it."""
+
+    @classmethod
+    def input_ports(cls) -> dict:
+        return {}
+
+    @classmethod
+    def output_ports(cls) -> dict:
+        return {}
+
+    def update(self) -> py_trees.common.Status:
+        return py_trees.common.Status.SUCCESS
+
+
 class TestPortsClassRegistry(unittest.TestCase):
-    """Auto-registration of PortsMixin subclasses for the XML parser."""
-
-    @staticmethod
-    def _make_leaf(**clskwargs: object) -> type:
-        class _Leaf(BehaviourWithPorts, **clskwargs):  # type: ignore[misc]
-            @classmethod
-            def input_ports(cls) -> dict:
-                return {}
-
-            @classmethod
-            def output_ports(cls) -> dict:
-                return {}
-
-            def update(self) -> py_trees.common.Status:
-                return py_trees.common.Status.SUCCESS
-
-        return _Leaf
+    """Auto-registration of PortsMixin subclasses for tree parsers."""
 
     def test_concrete_subclass_is_registered(self) -> None:
         # Producer is a concrete BehaviourWithPorts imported by the test helpers.
@@ -311,14 +310,18 @@ class TestPortsClassRegistry(unittest.TestCase):
         self.assertNotIn("BehaviourWithPorts", registry)
 
     def test_tag_alias_at_definition(self) -> None:
-        leaf = self._make_leaf(tag="AliasTag")
+        class AliasedLeaf(_RegistryLeaf, tag="AliasTag"):
+            pass
+
         registry = get_ports_registry()
-        self.assertIs(registry.get("AliasTag"), leaf)
-        self.assertNotIn(leaf.__name__, registry)
+        self.assertIs(registry.get("AliasTag"), AliasedLeaf)
+        self.assertNotIn("AliasedLeaf", registry)
 
     def test_register_false_opts_out(self) -> None:
-        leaf = self._make_leaf(register=False)
-        self.assertNotIn(leaf.__name__, get_ports_registry())
+        class HiddenLeaf(_RegistryLeaf, register=False):
+            pass
+
+        self.assertNotIn("HiddenLeaf", get_ports_registry())
 
     def test_register_ports_class_aliases(self) -> None:
         register_ports_class("ProducerAlias", Producer)
@@ -329,12 +332,16 @@ class TestPortsClassRegistry(unittest.TestCase):
             register_ports_class("NotAPort", py_trees.behaviour.Behaviour)
 
     def test_duplicate_name_warns_and_last_wins(self) -> None:
-        first = self._make_leaf(register=False)
-        second = self._make_leaf(register=False)
-        register_ports_class("DupTag", first)
+        class FirstLeaf(_RegistryLeaf, register=False):
+            pass
+
+        class SecondLeaf(_RegistryLeaf, register=False):
+            pass
+
+        register_ports_class("DupTag", FirstLeaf)
         with self.assertWarns(UserWarning):
-            register_ports_class("DupTag", second)
-        self.assertIs(get_ports_registry().get("DupTag"), second)
+            register_ports_class("DupTag", SecondLeaf)
+        self.assertIs(get_ports_registry().get("DupTag"), SecondLeaf)
 
 
 if __name__ == "__main__":

--- a/tests/test_ports_xml_parser.py
+++ b/tests/test_ports_xml_parser.py
@@ -28,7 +28,7 @@ from py_trees.ports_utils import (
     strip_trailing_uuid4,
 )
 
-from .test_ports_helpers import Consumer, ConsumerProducer, Producer
+from .test_ports_helpers import Consumer, Producer
 
 
 class StdoutLogger:
@@ -123,13 +123,6 @@ class TestXMLParser(unittest.TestCase):
         )
         self.tempfile.write(self.xml)
         self.tempfile.close()
-        # BehaviourWithPorts lookup for test helpers
-        self.init_lookup: dict[str, Any] = {
-            "Producer": Producer,
-            "Consumer": Consumer,
-            "ConsumerProducer": ConsumerProducer,
-        }
-
         self.factory = DummyFactory()
 
     def tearDown(self) -> None:
@@ -157,9 +150,7 @@ class TestXMLParser(unittest.TestCase):
 
     def test_xml_parser_remapping(self) -> None:
         """Ensure remapping between subtrees works correctly."""
-        root_node = parse_behaviour_tree_xml(
-            self.tempfile.name, init_lookup=self.init_lookup, logger=StdoutLogger()
-        )
+        root_node = parse_behaviour_tree_xml(self.tempfile.name, logger=StdoutLogger())
         # Wrap in a py_trees BehaviourTree and tick until complete
         btree = py_trees.trees.BehaviourTree(root_node)
         btree.tick()
@@ -170,9 +161,7 @@ class TestXMLParser(unittest.TestCase):
     def test_grandparent_xml(self) -> None:
         """Test XML parser with grandparent-child relationships and correct value propagation."""
         xml_path = os.path.join(os.path.dirname(__file__), "grandparent_test.xml")
-        root_node = parse_behaviour_tree_xml(
-            xml_path, init_lookup=self.init_lookup, logger=StdoutLogger()
-        )
+        root_node = parse_behaviour_tree_xml(xml_path, logger=StdoutLogger())
         btree = py_trees.trees.BehaviourTree(root_node)
         btree.tick()
         cons = find_node_by_name(btree.root, generate_node_name("ConsumerMain"))
@@ -219,11 +208,12 @@ class TestXMLParser(unittest.TestCase):
             tf.write(xml)
             temp_xml_path = tf.name
 
-        # Use partial to provide the extra argument
-        custom_lookup = dict(self.init_lookup)
-        custom_lookup["CustomBehaviourWithPorts"] = partial(
-            CustomBehaviourWithPorts, extra_arg="hello-world"
-        )
+        # Other classes auto-register; the partial injects the extra constructor arg.
+        custom_lookup = {
+            "CustomBehaviourWithPorts": partial(
+                CustomBehaviourWithPorts, extra_arg="hello-world"
+            )
+        }
 
         try:
             root_node = parse_behaviour_tree_xml(
@@ -259,12 +249,7 @@ class TestXMLParser(unittest.TestCase):
             tf.write(xml_content)
             temp_xml_path = tf.name
 
-        init_lookup = {
-            "Consumer": Consumer,
-            "Producer": Producer,
-        }
-
-        root = parse_behaviour_tree_xml(temp_xml_path, init_lookup=init_lookup)
+        root = parse_behaviour_tree_xml(temp_xml_path)
         btree = py_trees.trees.BehaviourTree(root)
         btree.tick()
 
@@ -277,9 +262,7 @@ class TestXMLParser(unittest.TestCase):
 
     def test_tree_structure(self) -> None:
         """Verify that the structure of the behavior tree matches the XML."""
-        root_node = parse_behaviour_tree_xml(
-            self.tempfile.name, init_lookup=self.init_lookup, logger=StdoutLogger()
-        )
+        root_node = parse_behaviour_tree_xml(self.tempfile.name, logger=StdoutLogger())
         # Check root node is a Sequence
         self.assertIsInstance(root_node, py_trees.composites.Sequence)
         self.assertEqual(len(root_node.children), 2)
@@ -318,9 +301,7 @@ class TestXMLParser(unittest.TestCase):
         self.tempfile.write(self.xml)
         self.tempfile.close()
 
-        root_node = parse_behaviour_tree_xml(
-            self.tempfile.name, init_lookup=self.init_lookup, logger=StdoutLogger()
-        )
+        root_node = parse_behaviour_tree_xml(self.tempfile.name, logger=StdoutLogger())
         btree = py_trees.trees.BehaviourTree(root_node)
 
         btree.tick()
@@ -356,9 +337,7 @@ class TestXMLParser(unittest.TestCase):
         self.tempfile.write(self.xml)
         self.tempfile.close()
 
-        root_node = parse_behaviour_tree_xml(
-            self.tempfile.name, init_lookup=self.init_lookup, logger=StdoutLogger()
-        )
+        root_node = parse_behaviour_tree_xml(self.tempfile.name, logger=StdoutLogger())
         btree = py_trees.trees.BehaviourTree(root_node)
 
         btree.tick()
@@ -405,9 +384,7 @@ class TestXMLParser(unittest.TestCase):
         self.tempfile.write(self.xml)
         self.tempfile.close()
 
-        root_node = parse_behaviour_tree_xml(
-            self.tempfile.name, init_lookup=self.init_lookup, logger=StdoutLogger()
-        )
+        root_node = parse_behaviour_tree_xml(self.tempfile.name, logger=StdoutLogger())
         btree = py_trees.trees.BehaviourTree(root_node)
 
         btree.tick()
@@ -555,12 +532,7 @@ class TestXMLParser(unittest.TestCase):
             path = tf.name
 
         try:
-            init_lookup = dict(self.init_lookup)
-            init_lookup["EchoCtorArgs"] = EchoCtorArgs
-
-            root = parse_behaviour_tree_xml(
-                path, init_lookup=init_lookup, logger=StdoutLogger()
-            )
+            root = parse_behaviour_tree_xml(path, logger=StdoutLogger())
             node = find_node_by_class(root, EchoCtorArgs)
             self.assertIsNotNone(node)
             # No auto type-casting: still strings
@@ -609,12 +581,7 @@ class TestXMLParser(unittest.TestCase):
             path = tf.name
 
         try:
-            init_lookup = dict(self.init_lookup)
-            init_lookup["PortAndCtor"] = PortAndCtor
-
-            root = parse_behaviour_tree_xml(
-                path, init_lookup=init_lookup, logger=StdoutLogger()
-            )
+            root = parse_behaviour_tree_xml(path, logger=StdoutLogger())
             tree = py_trees.trees.BehaviourTree(root)
             tree.tick()
 
@@ -659,12 +626,8 @@ class TestXMLParser(unittest.TestCase):
             tf.write(xml)
             path = tf.name
 
-        init_lookup = dict(self.init_lookup)
-        init_lookup["TakesKeyString"] = TakesKeyString
         with self.assertRaises(ValueError):
-            parse_behaviour_tree_xml(
-                path, init_lookup=init_lookup, logger=StdoutLogger()
-            )
+            parse_behaviour_tree_xml(path, logger=StdoutLogger())
         os.unlink(path)
 
     def test_direct_portsmixin_leaf_accepted(self) -> None:
@@ -715,10 +678,7 @@ class TestXMLParser(unittest.TestCase):
             path = tf.name
 
         try:
-            init_lookup = {"DirectPortsLeaf": DirectPortsLeaf}
-            root = parse_behaviour_tree_xml(
-                path, init_lookup=init_lookup, logger=StdoutLogger()
-            )
+            root = parse_behaviour_tree_xml(path, logger=StdoutLogger())
             tree = py_trees.trees.BehaviourTree(root)
             tree.tick()
             leaf = find_node_by_class(root, DirectPortsLeaf)
@@ -733,12 +693,6 @@ class TestXMLParserImports(unittest.TestCase):
 
     def setUp(self) -> None:
         py_trees.blackboard.Blackboard.clear()
-        # Reuse simple helpers
-        self.init_lookup: dict[str, Any] = {
-            "Producer": Producer,
-            "Consumer": Consumer,
-            "ConsumerProducer": ConsumerProducer,
-        }
 
     def _write_temp_xml(self, content: str) -> str:
         tf = tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".xml")
@@ -773,9 +727,7 @@ class TestXMLParserImports(unittest.TestCase):
         main_path = self._write_temp_xml(main_xml)
 
         try:
-            root = parse_behaviour_tree_xml(
-                main_path, init_lookup=self.init_lookup, logger=StdoutLogger()
-            )
+            root = parse_behaviour_tree_xml(main_path, logger=StdoutLogger())
             tree = py_trees.trees.BehaviourTree(root)
             tree.tick()
             c = find_node_by_name(root, "C", strip_prefix=True)
@@ -801,9 +753,7 @@ class TestXMLParserImports(unittest.TestCase):
 
         try:
             with self.assertRaises(ValueError):
-                parse_behaviour_tree_xml(
-                    main_path, init_lookup=self.init_lookup, logger=StdoutLogger()
-                )
+                parse_behaviour_tree_xml(main_path, logger=StdoutLogger())
         finally:
             os.unlink(lib_path)
             os.unlink(main_path)
@@ -824,9 +774,7 @@ class TestXMLParserImports(unittest.TestCase):
 
         try:
             with self.assertRaises(ValueError):
-                parse_behaviour_tree_xml(
-                    main_path, init_lookup=self.init_lookup, logger=StdoutLogger()
-                )
+                parse_behaviour_tree_xml(main_path, logger=StdoutLogger())
         finally:
             os.unlink(path_a)
             os.unlink(path_b)
@@ -841,9 +789,7 @@ class TestXMLParserImports(unittest.TestCase):
         main_path = self._write_temp_xml(main_xml)
         try:
             with self.assertRaises(FileNotFoundError):
-                parse_behaviour_tree_xml(
-                    main_path, init_lookup=self.init_lookup, logger=StdoutLogger()
-                )
+                parse_behaviour_tree_xml(main_path, logger=StdoutLogger())
         finally:
             os.unlink(main_path)
 
@@ -864,9 +810,7 @@ class TestXMLParserImports(unittest.TestCase):
         main_path = self._write_temp_xml(main_xml)
 
         try:
-            root = parse_behaviour_tree_xml(
-                main_path, init_lookup=self.init_lookup, logger=StdoutLogger()
-            )
+            root = parse_behaviour_tree_xml(main_path, logger=StdoutLogger())
             tree = py_trees.trees.BehaviourTree(root)
             tree.tick()
             x = find_node_by_name(root, "X", strip_prefix=True)
@@ -896,9 +840,7 @@ class TestXMLParserImports(unittest.TestCase):
 
         try:
             with self.assertRaises(ValueError):
-                parse_behaviour_tree_xml(
-                    main_path, init_lookup=self.init_lookup, logger=StdoutLogger()
-                )
+                parse_behaviour_tree_xml(main_path, logger=StdoutLogger())
         finally:
             os.unlink(lib_path)
             os.unlink(main_path)
@@ -934,7 +876,6 @@ class TestXMLParserImports(unittest.TestCase):
 
             root = parse_behaviour_tree_xml(
                 main_path,
-                init_lookup=self.init_lookup,
                 logger=StdoutLogger(),
                 search_paths=[d_lib],  # key part of this test
             )
@@ -957,9 +898,7 @@ class TestXMLParserImports(unittest.TestCase):
         )
         try:
             with self.assertRaises(ValueError):
-                parse_behaviour_tree_xml(
-                    main_path, init_lookup=self.init_lookup, logger=StdoutLogger()
-                )
+                parse_behaviour_tree_xml(main_path, logger=StdoutLogger())
         finally:
             os.unlink(lib_path)
             os.unlink(main_path)
@@ -980,9 +919,7 @@ class TestXMLParserImports(unittest.TestCase):
         self.tempfile.write(self.xml)
         self.tempfile.close()
 
-        root_node = parse_behaviour_tree_xml(
-            self.tempfile.name, init_lookup=self.init_lookup, logger=StdoutLogger()
-        )
+        root_node = parse_behaviour_tree_xml(self.tempfile.name, logger=StdoutLogger())
         btree = py_trees.trees.BehaviourTree(root_node)
 
         btree.tick()
@@ -1004,17 +941,12 @@ class TestXMLParserImports(unittest.TestCase):
         </BehaviorTree>
         </root>"""
 
-        init_lookup = dict(self.init_lookup)
-        init_lookup["FloatConsumer"] = FloatConsumer
-
         with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".xml") as tf:
             tf.write(xml)
             temp_xml_path = tf.name
 
         try:
-            root_node = parse_behaviour_tree_xml(
-                temp_xml_path, init_lookup=init_lookup, logger=StdoutLogger()
-            )
+            root_node = parse_behaviour_tree_xml(temp_xml_path, logger=StdoutLogger())
             btree = py_trees.trees.BehaviourTree(root_node)
             btree.tick()
 

--- a/tests/test_ports_xml_parser.py
+++ b/tests/test_ports_xml_parser.py
@@ -987,7 +987,7 @@ class TestAutoRegistration(unittest.TestCase):
         root_node = parse_behaviour_tree_xml(self.tempfile.name)
         py_trees.trees.BehaviourTree(root_node).tick()
         cons = find_node_by_name(root_node, "cons", strip_prefix=True)
-        self.assertIsInstance(cons, Consumer)
+        assert isinstance(cons, Consumer)
         self.assertEqual(cons.consumed_value, "Producer[/:prod]")
 
     def test_auto_register_false_with_empty_lookup_raises(self) -> None:

--- a/tests/test_ports_xml_parser.py
+++ b/tests/test_ports_xml_parser.py
@@ -20,7 +20,7 @@ from typing import Any
 import py_trees
 from py_trees.parsers.behaviour_tree_xml import is_key, parse_behaviour_tree_xml
 
-from py_trees.ports import BehaviourWithPorts, PortInformation
+from py_trees.ports import BehaviourWithPorts, get_ports_registry, PortInformation
 from py_trees.ports_utils import (
     find_node_by_class,
     find_node_by_name,
@@ -217,7 +217,7 @@ class TestXMLParser(unittest.TestCase):
 
         try:
             root_node = parse_behaviour_tree_xml(
-                temp_xml_path, init_lookup=custom_lookup, logger=StdoutLogger()
+                temp_xml_path, node_registry=custom_lookup, logger=StdoutLogger()
             )
             custom = find_node_by_class(root_node, CustomBehaviourWithPorts)
             self.assertIsNotNone(custom)
@@ -427,10 +427,10 @@ class TestXMLParser(unittest.TestCase):
         self.tempfile.write(self.xml)
         self.tempfile.close()
 
-        init_lookup = {"Wait": partial(Wait, factory=self.factory)}
+        node_registry = {"Wait": partial(Wait, factory=self.factory)}
 
         root_node = parse_behaviour_tree_xml(
-            self.tempfile.name, init_lookup=init_lookup, logger=StdoutLogger()
+            self.tempfile.name, node_registry=node_registry, logger=StdoutLogger()
         )
         btree = py_trees.trees.BehaviourTree(root_node)
 
@@ -467,7 +467,7 @@ class TestXMLParser(unittest.TestCase):
         # Getting from the registry
         SMALL_JOINT_NAMES = [f"robot_small_joint_{i}" for i in range(1, 7)]
         BIG_JOINT_NAMES = [f"robot_big_joint_{i}" for i in range(1, 7)]
-        init_lookup = get_behaviors_lookup(
+        node_registry = get_behaviors_lookup(
             self.factory,
             {
                 0: RobotData("robot_small", SMALL_JOINT_NAMES, None),
@@ -476,7 +476,7 @@ class TestXMLParser(unittest.TestCase):
         )
 
         root_node = parse_behaviour_tree_xml(
-            self.tempfile.name, init_lookup=init_lookup, logger=StdoutLogger()
+            self.tempfile.name, node_registry=node_registry, logger=StdoutLogger()
         )
         btree = py_trees.trees.BehaviourTree(root_node)
 
@@ -958,8 +958,8 @@ class TestXMLParserImports(unittest.TestCase):
             os.unlink(temp_xml_path)
 
 
-class TestAutoRegistration(unittest.TestCase):
-    """Auto-registration and the optional ``init_lookup`` in the XML parser."""
+class TestNodeRegistry(unittest.TestCase):
+    """The ``node_registry`` argument: ``"auto"`` vs an explicit dict."""
 
     XML = """<root main_tree_to_execute="MainTree">
         <BehaviorTree ID="MainTree">
@@ -982,45 +982,63 @@ class TestAutoRegistration(unittest.TestCase):
     def tearDown(self) -> None:
         os.unlink(self.tempfile.name)
 
-    def test_auto_only_no_init_lookup(self) -> None:
-        """Classes resolve purely via auto-registration when no init_lookup is given."""
+    def test_auto_is_the_default(self) -> None:
+        """With no node_registry, every tag resolves from the auto-registry."""
         root_node = parse_behaviour_tree_xml(self.tempfile.name)
         py_trees.trees.BehaviourTree(root_node).tick()
         cons = find_node_by_name(root_node, "cons", strip_prefix=True)
         assert isinstance(cons, Consumer)
         self.assertEqual(cons.consumed_value, "Producer[/:prod]")
 
-    def test_auto_register_false_with_empty_lookup_raises(self) -> None:
-        """With auto-registration off and no init_lookup, there are no classes to use."""
-        with self.assertRaises(ValueError):
-            parse_behaviour_tree_xml(self.tempfile.name, auto_register=False)
+    def test_auto_string_is_equivalent_to_default(self) -> None:
+        """Passing node_registry="auto" explicitly behaves like the default."""
+        root_node = parse_behaviour_tree_xml(self.tempfile.name, node_registry="auto")
+        cons = find_node_by_name(root_node, "cons", strip_prefix=True)
+        self.assertIsInstance(cons, Consumer)
 
-    def test_auto_register_false_uses_only_init_lookup(self) -> None:
-        """With auto-registration off, a class missing from init_lookup is not found."""
+    def test_invalid_registry_string_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_behaviour_tree_xml(self.tempfile.name, node_registry="nope")
+
+    def test_non_dict_non_str_registry_raises(self) -> None:
+        with self.assertRaises(TypeError):
+            parse_behaviour_tree_xml(
+                self.tempfile.name,
+                node_registry=["Producer"],  # type: ignore[arg-type]
+            )
+
+    def test_empty_dict_raises(self) -> None:
+        """An explicit empty registry leaves the parser with no classes."""
+        with self.assertRaises(ValueError):
+            parse_behaviour_tree_xml(self.tempfile.name, node_registry={})
+
+    def test_explicit_dict_replaces_auto(self) -> None:
+        """A dict is used exclusively: a tag missing from it is not resolved."""
         with self.assertRaises(ValueError):
             parse_behaviour_tree_xml(
                 self.tempfile.name,
-                init_lookup={"Producer": Producer},  # Consumer deliberately omitted
-                auto_register=False,
+                node_registry={"Producer": Producer},  # Consumer deliberately omitted
             )
 
-    def test_init_lookup_overrides_registry(self) -> None:
-        """An init_lookup entry shadows the auto-registered class of the same name."""
+    def test_explicit_entry_overrides_auto_via_spread(self) -> None:
+        """Spreading the auto-registry lets one entry override a single tag."""
 
         class OverrideProducer(Producer, register=False):
             pass
 
         root_node = parse_behaviour_tree_xml(
-            self.tempfile.name, init_lookup={"Producer": OverrideProducer}
+            self.tempfile.name,
+            node_registry={**get_ports_registry(), "Producer": OverrideProducer},
         )
         prod = find_node_by_name(root_node, "prod", strip_prefix=True)
         self.assertIsInstance(prod, OverrideProducer)
 
-    def test_auto_plus_partial_injection(self) -> None:
-        """Auto-registration resolves classes; init_lookup injects runtime deps via partial."""
+    def test_partial_injection_alongside_auto(self) -> None:
+        """The documented pattern: auto-registry spread plus a partial for DI."""
         xml = """<root main_tree_to_execute="MainTree">
             <BehaviorTree ID="MainTree">
               <Sequence>
+                <Producer name="prod" output="{final}" />
                 <Wait name="w" input_duration_ms="0" />
               </Sequence>
             </BehaviorTree>
@@ -1029,14 +1047,19 @@ class TestAutoRegistration(unittest.TestCase):
             tf.write(xml)
             temp_xml_path = tf.name
         try:
-            # Wait needs a `factory` dependency -> supplied via init_lookup partial,
-            # while still benefiting from auto-registration for any other classes.
+            # Producer resolves via the auto-registry spread; Wait needs a `factory`
+            # dependency, supplied via a partial that only the per-call dict can carry.
             root_node = parse_behaviour_tree_xml(
                 temp_xml_path,
-                init_lookup={"Wait": partial(Wait, factory=DummyFactory())},
+                node_registry={
+                    **get_ports_registry(),
+                    "Wait": partial(Wait, factory=DummyFactory()),
+                },
             )
-            node = find_node_by_name(root_node, "w", strip_prefix=True)
-            self.assertIsInstance(node, Wait)
+            wait = find_node_by_name(root_node, "w", strip_prefix=True)
+            prod = find_node_by_name(root_node, "prod", strip_prefix=True)
+            self.assertIsInstance(wait, Wait)
+            self.assertIsInstance(prod, Producer)
         finally:
             os.unlink(temp_xml_path)
 

--- a/tests/test_ports_xml_parser.py
+++ b/tests/test_ports_xml_parser.py
@@ -1026,5 +1026,88 @@ class TestXMLParserImports(unittest.TestCase):
             os.unlink(temp_xml_path)
 
 
+class TestAutoRegistration(unittest.TestCase):
+    """Auto-registration and the optional ``init_lookup`` in the XML parser."""
+
+    XML = """<root main_tree_to_execute="MainTree">
+        <BehaviorTree ID="MainTree">
+          <Sequence>
+            <Producer name="prod" output="{final}" />
+            <Consumer name="cons" input="{final}" />
+          </Sequence>
+        </BehaviorTree>
+      </root>"""
+
+    def setUp(self) -> None:
+        py_trees.blackboard.Blackboard.clear()
+        # Producer/Consumer are concrete BehaviourWithPorts -> auto-registered on import.
+        self.tempfile = tempfile.NamedTemporaryFile(
+            delete=False, mode="w", suffix=".xml"
+        )
+        self.tempfile.write(self.XML)
+        self.tempfile.close()
+
+    def tearDown(self) -> None:
+        os.unlink(self.tempfile.name)
+
+    def test_auto_only_no_init_lookup(self) -> None:
+        """Classes resolve purely via auto-registration when no init_lookup is given."""
+        root_node = parse_behaviour_tree_xml(self.tempfile.name)
+        py_trees.trees.BehaviourTree(root_node).tick()
+        cons = find_node_by_name(root_node, "cons", strip_prefix=True)
+        self.assertIsInstance(cons, Consumer)
+        self.assertEqual(cons.consumed_value, "Producer[/:prod]")
+
+    def test_auto_register_false_with_empty_lookup_raises(self) -> None:
+        """With auto-registration off and no init_lookup, there are no classes to use."""
+        with self.assertRaises(ValueError):
+            parse_behaviour_tree_xml(self.tempfile.name, auto_register=False)
+
+    def test_auto_register_false_uses_only_init_lookup(self) -> None:
+        """With auto-registration off, a class missing from init_lookup is not found."""
+        with self.assertRaises(ValueError):
+            parse_behaviour_tree_xml(
+                self.tempfile.name,
+                init_lookup={"Producer": Producer},  # Consumer deliberately omitted
+                auto_register=False,
+            )
+
+    def test_init_lookup_overrides_registry(self) -> None:
+        """An init_lookup entry shadows the auto-registered class of the same name."""
+
+        class OverrideProducer(Producer, register=False):
+            pass
+
+        root_node = parse_behaviour_tree_xml(
+            self.tempfile.name, init_lookup={"Producer": OverrideProducer}
+        )
+        prod = find_node_by_name(root_node, "prod", strip_prefix=True)
+        self.assertIsInstance(prod, OverrideProducer)
+
+    def test_auto_plus_partial_injection(self) -> None:
+        """Auto-registration resolves classes; init_lookup injects runtime deps via partial."""
+        xml = """<root main_tree_to_execute="MainTree">
+            <BehaviorTree ID="MainTree">
+              <Sequence>
+                <Wait name="w" input_duration_ms="0" />
+              </Sequence>
+            </BehaviorTree>
+          </root>"""
+        with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".xml") as tf:
+            tf.write(xml)
+            temp_xml_path = tf.name
+        try:
+            # Wait needs a `factory` dependency -> supplied via init_lookup partial,
+            # while still benefiting from auto-registration for any other classes.
+            root_node = parse_behaviour_tree_xml(
+                temp_xml_path,
+                init_lookup={"Wait": partial(Wait, factory=DummyFactory())},
+            )
+            node = find_node_by_name(root_node, "w", strip_prefix=True)
+            self.assertIsInstance(node, Wait)
+        finally:
+            os.unlink(temp_xml_path)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is an improvement to the XML parser which can parse behaviors with ports (`PortsMixin` derived classes).

An XML tag like ``<MyNode>`` is just a name --- before the parser can build the node it has to find the Python class that name refers to. To date, we have to manually resolve this by specifying a `name --> class` mapping and resolving it in an `init_lookup` function. This PR eliminates the need to do that and auto-registers all PortsMixin-derived classes in a registry. The `init_lookup` method can still be used like before.

## Test plan

Run the unit tests