### PR TITLE
[ports] Split list/tuple value strings based on comma or semicolon

### DIFF
--- a/py_trees/ports_utils.py
+++ b/py_trees/ports_utils.py
@@ -163,7 +163,7 @@ def convert_str_to_type(
 
     if origin is list:
         (inner_type,) = get_args(target_type) or (str,)
-        parts = [p.strip() for p in value.split(",")] if value.strip() else []
+        parts = [p.strip() for p in re.split(r"[,;]", value)] if value.strip() else []
         try:
             return [convert_str_to_type(p, inner_type, logger) for p in parts]
         except Exception:
@@ -171,7 +171,7 @@ def convert_str_to_type(
 
     if origin is tuple:
         inner_types = get_args(target_type)
-        parts = [p.strip() for p in value.split(",")]
+        parts = [p.strip() for p in re.split(r"[,;]", value)]
         converted = []
         for i, p in enumerate(parts):
             t = inner_types[i] if i < len(inner_types) else str


### PR DESCRIPTION
To be consistent with BT.CPP syntax, which uses semicolons as list delimiters in XML port values, we should support this too!

@JenniferBuehler what do you think?