### PR TITLE
[ports] Convert constructor kwargs to types defined in parent classes

### DIFF
--- a/py_trees/ports_utils.py
+++ b/py_trees/ports_utils.py
@@ -182,6 +182,52 @@ def convert_str_to_type(value: str, target_type: type | UnionType, logger: Ports
     return value
 
 
+def collect_type_hints(constructor: Callable) -> dict[str, Any]:
+    """Collect parameter type hints from a constructor.
+
+    When ``constructor`` is a class, the method resolution order (MRO) is walked so
+    that a type hint declared on a parent's ``__init__`` is still found when the
+    subclass forwards ``**kwargs`` to ``super().__init__()``, and therefore does
+    not declare the parameter itself, or declares it without an annotation.
+
+    The most-derived annotation for a given parameter name wins: walking the MRO
+    from subclass to base and only recording the first hint seen per parameter.
+
+    Args:
+        constructor: A class (whose ``__init__`` chain is inspected) or a callable.
+
+    Returns:
+        dict[str, Any]: Mapping of parameter name to its type annotation. Parameters
+            without an annotation anywhere in the hierarchy are omitted, as are
+            ``self`` and any ``*args``/``**kwargs`` catch-alls.
+    """
+    classes = constructor.__mro__ if inspect.isclass(constructor) else (constructor,)
+
+    hints: dict[str, Any] = {}
+    for klass in classes:
+        func = klass.__init__ if inspect.isclass(klass) else klass
+        try:
+            sig = inspect.signature(func)
+        except (TypeError, ValueError):
+            # Built-ins (e.g. object.__init__ on some interpreters) may not be
+            # introspectable; just skip them and keep walking the hierarchy.
+            continue
+
+        for pname, param in sig.parameters.items():
+            if pname == "self":
+                continue
+            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                continue
+            if param.annotation is inspect._empty:
+                continue
+            # The first hint found wins => the most-derived class in the MRO.
+            if pname in hints:
+                continue
+            hints[pname] = param.annotation
+
+    return hints
+
+
 def apply_type_hints(
     constructor: Callable,
     kwargs: dict[str, Any],
@@ -207,13 +253,7 @@ def apply_type_hints(
     if logger is None:
         logger = NOOP_LOGGER
 
-    sig = inspect.signature(constructor.__init__ if inspect.isclass(constructor) else constructor)
-    hints: dict[str, Any] = {}
-    for pname, param in sig.parameters.items():
-        if pname == "self":
-            continue
-        if param.annotation is not inspect._empty:
-            hints[pname] = param.annotation
+    hints = collect_type_hints(constructor)
 
     converted: dict[str, Any] = {}
     success = True

--- a/tests/test_ports_xml_parser.py
+++ b/tests/test_ports_xml_parser.py
@@ -83,6 +83,34 @@ class Wait(BehaviourWithPorts):
         return self.get_input(self.INPUT_DURATION_MS_PORT)
 
 
+class EchoCtorArgs(BehaviourWithPorts):
+    """Behaviour that tests interpreting constructor type hints for type coercion from XML ports."""
+
+    @classmethod
+    def input_ports(cls) -> dict:
+        return {"in": PortInformation(data_type=str, required=False)}  # not used here
+
+    @classmethod
+    def output_ports(cls) -> dict:
+        return {"out": PortInformation(data_type=str, required=False)}  # not used here
+
+    def __init__(self, name: str, greeting: str, times: float | None, flag: bool, **kwargs: Any) -> None:
+        super().__init__(name, **kwargs)
+        self.greeting = greeting
+        self.times = times
+        self.flag = flag
+
+
+class EchoCtorArgsChild(EchoCtorArgs):
+    """
+    Behaviour that tests interpreting constructor type hints for type coercion from XML ports,
+    but from its parent class.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
 @dataclass
 class RobotData:
     type: str
@@ -471,21 +499,6 @@ class TestXMLParser(unittest.TestCase):
         Values are automatically converted based on the type hints in the constructor.
         """
 
-        class EchoCtorArgs(BehaviourWithPorts):
-            @classmethod
-            def input_ports(cls) -> dict:
-                return {"in": PortInformation(data_type=str, required=False)}  # not used here
-
-            @classmethod
-            def output_ports(cls) -> dict:
-                return {"out": PortInformation(data_type=str, required=False)}  # not used here
-
-            def __init__(self, name: str, greeting: str, times: float | None, flag: bool, **kwargs: Any) -> None:
-                super().__init__(name, **kwargs)
-                self.greeting = greeting
-                self.times = times
-                self.flag = flag
-
         xml = """<root main_tree_to_execute="Main">
         <BehaviorTree ID="Main">
           <Sequence>
@@ -500,6 +513,33 @@ class TestXMLParser(unittest.TestCase):
 
         root = parse_behaviour_tree_xml(path, logger=StdoutLogger())
         node = find_node_by_class(root, EchoCtorArgs)
+        self.assertIsNotNone(node)
+        self.assertEqual(node.greeting, "hello")
+        self.assertEqual(node.times, 3.0)
+        self.assertEqual(node.flag, True)
+
+        os.unlink(path)
+
+    def test_ctor_args_passed_as_kwargs_in_parent_class(self) -> None:
+        """
+        Non-port XML attributes must be passed as constructor kwargs.
+        Values are automatically converted based on the type hints in the parent class constructor.
+        """
+
+        xml = """<root main_tree_to_execute="Main">
+        <BehaviorTree ID="Main">
+          <Sequence>
+            <EchoCtorArgsChild name="E1" greeting="hello" times="3" flag="true"/>
+          </Sequence>
+        </BehaviorTree>
+      </root>"""
+
+        with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".xml") as tf:
+            tf.write(xml)
+            path = tf.name
+
+        root = parse_behaviour_tree_xml(path, logger=StdoutLogger())
+        node = find_node_by_class(root, EchoCtorArgsChild)
         self.assertIsNotNone(node)
         self.assertEqual(node.greeting, "hello")
         self.assertEqual(node.times, 3.0)


### PR DESCRIPTION
Another small yet useful update to ports (cc @JenniferBuehler)

In this case, if a `BehaviourWithPorts` class does not define type hints in its own constructor, because it's derived from a parent, the XML parser will actually walk up the hierarchy.

I ran into this case because I made a base class for e.g. calling a ROS service, wherein I defined a `float` constructor argument in the base class for service call timeouts. However, the child class just directly passed through the `kwargs` structure so this value was interpreted as a regular string.

Added a test for this.