### PR TITLE
[ports] Add default values to PortInformation

### DIFF
--- a/docs/ports.rst
+++ b/docs/ports.rst
@@ -101,6 +101,52 @@ In the example above, another node's output ports would typically be remapped to
     Because the remapping table usually cannot be computed until the entire tree topology is known — either the user assembles it by hand or a parser generates it from e.g. XML (more on that next).
     See :class:`py_trees.ports.PortsMixin` for the full contract and semantics.
 
+Default values
+~~~~~~~~~~~~~~
+
+A port can declare a ``default_value`` next to its type, so the fallback lives with the port declaration rather than being repeated at every call site:
+
+.. code-block:: python
+
+   @classmethod
+   def input_ports(cls):
+       return {
+           "timeout": PortInformation(data_type=float, default_value=5.0),
+       }
+
+   def update(self):
+       timeout = self.get_input("timeout")   # 5.0 unless something wrote to the port
+
+The semantics are:
+
+* **Validated at declaration time.**
+  The default is type-checked against ``data_type`` when the :class:`~py_trees.ports.PortInformation` is constructed, so a mismatch raises ``TypeError`` where the port is declared instead of surfacing on a tick.
+
+* **Applied whenever no data is available.**
+  That covers both an unwired port and a port wired to a key nothing has written to yet.
+  Any actual data on the port wins over the default.
+
+* **They make a port satisfiable, including a required one.**
+  ``required=True`` together with a default reads as "this node always needs a value here, and here is the fallback"; such a port never raises :class:`~py_trees.ports.NoDataAvailable`.
+  It is also not registered as a *required* blackboard key, so :meth:`~py_trees.blackboard.Client.verify_required_keys_exist` does not trip over it.
+
+* **A call-site default still wins.**
+  ``get_input("timeout", default=1.0)`` overrides the declared default for that read.
+
+* **Input defaults are read-side only.**
+  They are never written to the blackboard, so wiring a defaulted input port to a shared key does not seed that key for other readers.
+  Container defaults (e.g., a list) are deep-copied on the way out, so a caller mutating the returned value cannot corrupt the declaration shared by every instance of the class.
+
+* **Output defaults are seeded onto the blackboard.**
+  An output port's default is written by ``setup_ports()``, so nodes wired to that port read a value before the producing node has ticked; whatever the node writes later replaces it.
+  Unlike input defaults, this does touch shared state — if two output ports are wired to the same key, the last one set up wins.
+
+* **Reset returns a port to its default.**
+  :meth:`~py_trees.ports.PortsMixin.reset_port` (and ``reset_all_output_ports()``) re-seeds an output port that declares a default instead of leaving it empty, so the guarantee that readers always see a value survives a "new data epoch".
+  Ports without a default are cleared as before.
+
+Note that ``default_value=None`` means "no default declared" — ``None`` is not supported as a port value in any case.
+
 .. _ports-xml-parser-label:
 
 Experimental XML parser

--- a/py_trees/ports.py
+++ b/py_trees/ports.py
@@ -13,8 +13,7 @@
 # Imports
 ##############################################################################
 
-import types
-import typing
+import copy
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -26,6 +25,7 @@ from .ports_utils import (
     LogLevel,
     PortsLogger,
     convert_str_to_type,
+    is_instance_of_type,
     reset_blackboard_key,
     sanitize_name_for_blackboard_use,
     set_feedback_and_log,
@@ -59,11 +59,41 @@ class NoDataAvailable(Exception):  # noqa: N818
 
 @dataclass(frozen=True)
 class PortInformation:
-    """Static declaration for one typed input or output port."""
+    """
+    Static declaration for one input or output port.
+
+    Args:
+        data_type: The type of the data carried by this port.
+            Values read from or written to the port are checked against it at runtime.
+        required: Whether the port must resolve to data. Required input ports without data
+            raise :class:`NoDataAvailable` when read, unless a *default_value* is declared,
+            which always satisfies the requirement.
+        description: Optional human-readable description of the port.
+        default_value: Optional initial value for the port, validated against *data_type*
+            at construction time. ``None`` means that no default value is declared.
+
+    Raises:
+        TypeError: If *default_value* does not match *data_type*.
+    """
 
     data_type: Any
     required: bool = True
     description: str = ""
+    default_value: Any = None
+
+    def __post_init__(self) -> None:
+        """Validate the declared default value against the declared data type."""
+        if self.default_value is None:
+            return
+        if not is_instance_of_type(self.default_value, self.data_type):
+            raise TypeError(
+                f"Default value '{self.default_value}' is not of type {self.data_type}, but {type(self.default_value)}."
+            )
+
+    @property
+    def has_default(self) -> bool:
+        """Return whether this port declares a default value."""
+        return self.default_value is not None
 
 
 ##############################################################################
@@ -149,7 +179,7 @@ class PortsMixin(_MixinBase):
     These port definitions are used to:
 
     1. Register blackboard keys for communication.
-    2. Enforce type and presence validation at runtime.
+    2. Enforce type, default values, and presence validation at runtime.
     3. Provide clear contracts for each behaviour's data dependencies and outputs.
 
     Example usage::
@@ -157,7 +187,7 @@ class PortsMixin(_MixinBase):
         class MyBehaviour(PortsMixin, py_trees.behaviour.Behaviour):
             @classmethod
             def input_ports(cls):
-                return {"input": PortInformation(data_type=str, required=True)}
+                return {"input": PortInformation(data_type=str, default_value="foo", required=True)}
 
             @classmethod
             def output_ports(cls):
@@ -305,6 +335,9 @@ class PortsMixin(_MixinBase):
     def is_port_required(cls, port_name: str) -> bool:
         """Return whether the specified port is marked as required.
 
+        Note that a port declaring a default value is always satisfiable, even when marked
+        as required, since the default is applied whenever no data is available.
+
         Args:
             port_name (str): The name of the input or output port.
 
@@ -440,10 +473,12 @@ class PortsMixin(_MixinBase):
                 # like "transfer" would become the global literal key "/transfer"
                 # and collide across sibling subtrees.
                 key = py_trees.blackboard.Blackboard.absolute_name(subtree_namespace, key)
+                # A port with a default value is satisfiable without data on the blackboard, so it
+                # must not be registered as required (that would fail verify_required_keys_exist()).
                 self._blackboard_client.register_key(
                     key=port,
                     access=py_trees.common.Access.READ,
-                    required=self.is_port_required(port),
+                    required=self.is_port_required(port) and not self.input_ports()[port].has_default,
                     remap_to=key,
                 )
                 abs_port_name = self.blackboard_client.absolute_name(port)
@@ -473,7 +508,7 @@ class PortsMixin(_MixinBase):
                 self._blackboard_client.register_key(
                     key=port,
                     access=py_trees.common.Access.READ,
-                    required=self.is_port_required(port),
+                    required=self.is_port_required(port) and not self.input_ports()[port].has_default,
                     remap_to=storage_key,
                 )
         for port in self.output_ports():
@@ -486,6 +521,20 @@ class PortsMixin(_MixinBase):
                     required=self.is_port_required(port),
                     remap_to=storage_key,
                 )
+
+        # Seed declared defaults on output ports, so that readers wired to them see a value
+        # before this node has ticked. Input defaults are *not* seeded: they are applied on the
+        # read side by get_input(), so they cannot leak into a key that other nodes read from.
+        for port, port_information in self.output_ports().items():
+            if port_information.has_default:
+                self._seed_output_default(port, port_information)
+
+    def _seed_output_default(self, port_name: str, port_information: PortInformation) -> None:
+        """Write the declared default of an output port to the blackboard."""
+        # Deep copy so that whoever reads the value back cannot mutate the port declaration
+        # shared by every instance of this class.
+        self._set_output(port_name, copy.deepcopy(port_information.default_value))
+        self.log_debug(f"Port {port_name}: Seeded default value '{port_information.default_value}'.")
 
     @property
     def subtree_namespace(self) -> str:
@@ -520,40 +569,6 @@ class PortsMixin(_MixinBase):
             str: The registered name of this behavior class.
         """
         return self._behaviour_class_name
-
-    def _is_instance_of_type(self, value: Any, expected_type: Any) -> bool:
-        """
-        Check if a value is an instance of a specific type.
-
-        Extends Python's isinstance() to check for generic types, such as lists.
-
-        Currently this only supports basic types (int, float, etc.) and the generic types Union and list.
-        Add additional type support as needed.
-
-        Args:
-            value (Any): The value to check.
-            expected_type (type): The expected type.
-
-        Returns:
-            bool: True if the value is an instance of the expected type, False otherwise.
-
-        Raises:
-            NotImplementedError: If type checking for the specific generic type is not implemented.
-        """
-        origin = typing.get_origin(expected_type)
-        args = typing.get_args(expected_type)
-        # Handle union types first
-        if origin is typing.Union or origin is types.UnionType:  # Need to also check types.UnionType to cover | syntax
-            return any(self._is_instance_of_type(value, arg) for arg in args)
-        # Handle other generics
-        if origin is not None:
-            if not isinstance(value, origin):
-                return False
-            if origin is list and args:
-                return all(self._is_instance_of_type(v, args[0]) for v in value)
-            raise NotImplementedError(f"Type checking for generic type '{origin}' is not implemented.")
-        else:
-            return isinstance(value, expected_type)
 
     def get_logger(self) -> PortsLogger:
         """Return the logger instance.
@@ -604,10 +619,19 @@ class PortsMixin(_MixinBase):
     def get_input(self, port_name: str, default: Any = None) -> Any:
         """Read the value of the given input port from the blackboard.
 
+        When no data is available on the port, the fallbacks are applied in this order:
+
+        1. The *default* argument given here, if it is not ``None``.
+        2. The ``default_value`` declared on the port's :class:`PortInformation`, if it has one.
+           Declared defaults are deep-copied on the way out, so a caller mutating the returned
+           value cannot corrupt the class-level declaration.
+        3. Otherwise, :class:`NoDataAvailable` is raised.
+
         Args:
             port_name (str): The name of the input port to read from the blackboard.
             default (Any): Optional default value to return if the port has no input data.
-            If set to `None`, no default is accepted.
+                It takes precedence over a default declared on the port.
+                If set to `None`, only a default declared on the port (if any) is accepted.
         Return:
             Any: The value retrieved from the blackboard for the specified input port or the default.
 
@@ -621,10 +645,16 @@ class PortsMixin(_MixinBase):
         if not self.blackboard_client.is_registered(port_name):
             raise KeyError(f"{self.name}: Input port '{port_name}' is not registered in the blackboard client.")
         # Get the value from the blackboard
-        # If the port is not set, return the default value if provided, otherwise raise an error.
+        # If the port is not set, fall back to a default (argument first, then the declared
+        # default value on the port), otherwise raise an error.
         if not self.blackboard_client.exists(port_name):
             if default is not None:
                 return default
+            port_information = self.input_ports()[port_name]
+            if port_information.has_default:
+                # Deep copy so that a caller mutating a container default (e.g. a list) does not
+                # modify the port declaration shared by every instance of this class.
+                return copy.deepcopy(port_information.default_value)
             raise NoDataAvailable(
                 f"{self.name}: Input port '{port_name}' (mapped to "
                 f"'{self._get_blackboard_key(port_name)}') has no data available."
@@ -634,13 +664,16 @@ class PortsMixin(_MixinBase):
         if value is None:
             raise NotImplementedError("Support for None values has not yet been considered.")
         port_type = self.input_ports()[port_name].data_type
-        if not self._is_instance_of_type(value, port_type):
+        if not is_instance_of_type(value, port_type):
             raise TypeError(f"{self.name}: Value '{value}' is not of type {port_type}, but {type(value)}")
         return value
 
     def get_last_output(self, port_name: str) -> Any:
         """
         Return the last output which the node wrote at this port.
+
+        If the port declares a default value, that default is present from ``setup_ports()``
+        onwards, so this returns it until the node writes something.
 
         Args:
             port_name (str): The name of the output port to read from the blackboard.
@@ -663,7 +696,7 @@ class PortsMixin(_MixinBase):
         if value is None:
             raise NotImplementedError("Support for explicit None values has not yet been considered.")
         port_type = self.output_ports()[port_name].data_type
-        if not self._is_instance_of_type(value, port_type):
+        if not is_instance_of_type(value, port_type):
             raise TypeError(f"{self.name}: Value '{value}' is not of type {port_type}")
         return value
 
@@ -684,21 +717,22 @@ class PortsMixin(_MixinBase):
         if port_name not in self.output_ports():
             raise KeyError(f"{self.name}: Output port '{port_name}' not defined.")
         port_type = self.output_ports()[port_name].data_type
-        if not self._is_instance_of_type(value, port_type):
+        if not is_instance_of_type(value, port_type):
             raise TypeError(f"{self.name}: Value '{value}' is not of type {port_type}")
 
         self.blackboard_client.set(port_name, value)
 
     def reset_port(self, port_name: str) -> None:
         """
-        Clear the value stored for a (usually output) port.
+        Reset a (usually output) port to its initial state.
 
         Keeps the key registered (READ/WRITE permissions unaffected), but removes
         the stored value. Intended for use-cases like "new data epoch" where
         downstream nodes should not read stale outputs.
 
         This will have the effect that subsequent
-        `blackboard_client.exists(port_name)` returns False again
+        `blackboard_client.exists(port_name)` returns False again, unless the port is an
+        output port declaring a default value. In that case, that default is seeded again.
 
         Raises:
             KeyError: if the port is unknown or not registered.
@@ -709,16 +743,21 @@ class PortsMixin(_MixinBase):
 
         reset_blackboard_key(self.blackboard_client, port_name, node_name=self.name)
 
+        output_port_information = self.output_ports().get(port_name)
+        if output_port_information is not None and output_port_information.has_default:
+            self._seed_output_default(port_name, output_port_information)
+
     def reset_all_output_ports(self) -> None:
         """
-        Clear all output ports registered on this node.
+        Reset all output ports registered on this node to their initial state.
 
         Keeps the keys registered (READ/WRITE permissions unaffected), but removes
         the stored values. Intended for use-cases like "new data epoch" where
         downstream nodes should not read stale outputs.
 
         This will have the effect that subsequent
-        `blackboard_client.exists(port_name)` returns False again
+        `blackboard_client.exists(port_name)` returns False again, except for ports declaring
+        a default value, which are seeded again (see :meth:`reset_port`).
 
         Raises:
             KeyError: if any port is unknown or not registered.

--- a/py_trees/ports_utils.py
+++ b/py_trees/ports_utils.py
@@ -182,6 +182,41 @@ def convert_str_to_type(value: str, target_type: type | UnionType, logger: Ports
     return value
 
 
+def is_instance_of_type(value: Any, expected_type: Any) -> bool:
+    """
+    Check if a value is an instance of a specific type.
+
+    Extends Python's isinstance() to check for generic types, such as lists.
+
+    Currently this only supports basic types (int, float, etc.) and the generic types Union and list.
+    Add additional type support as needed.
+
+    Args:
+        value (Any): The value to check.
+        expected_type (Any): The expected type.
+
+    Returns:
+        bool: True if the value is an instance of the expected type, False otherwise.
+
+    Raises:
+        NotImplementedError: If type checking for the specific generic type is not implemented.
+    """
+    origin = get_origin(expected_type)
+    args = get_args(expected_type)
+    # Handle union types first
+    if origin is Union or origin is UnionType:  # Need to also check types.UnionType to cover | syntax
+        return any(is_instance_of_type(value, arg) for arg in args)
+    # Handle other generics
+    if origin is not None:
+        if not isinstance(value, origin):
+            return False
+        if origin is list and args:
+            return all(is_instance_of_type(v, args[0]) for v in value)
+        raise NotImplementedError(f"Type checking for generic type '{origin}' is not implemented.")
+    else:
+        return isinstance(value, expected_type)
+
+
 def collect_type_hints(constructor: Callable) -> dict[str, Any]:
     """Collect parameter type hints from a constructor.
 

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -14,62 +14,61 @@ import py_trees
 from py_trees.ports import (
     BehaviourWithPorts,
     NoDataAvailable,
+    PortInformation,
     get_ports_registry,
     register_ports_class,
 )
+from py_trees.ports_utils import is_instance_of_type
 
-from .test_ports_helpers import Consumer, ConsumerProducer, Producer
+from .test_ports_helpers import Consumer, ConsumerProducer, Producer, seed_blackboard_value
 
 
 # TODO: Add more tests for PortsMixin methods as needed. There are also some tests that can be ported over from
 # test_behavior_with_ports.py to here.
-class TestPortsMixin(unittest.TestCase):
-    def setUp(self) -> None:
-        self.mixin = Producer("test")  # Use Producer class so we don't have to worry about PortsMixin abstract methods
-
+class TestIsInstanceOfType(unittest.TestCase):
     def test_basic_types(self) -> None:
-        self.assertTrue(self.mixin._is_instance_of_type(5, int))
-        self.assertTrue(self.mixin._is_instance_of_type(3.14, float))
-        self.assertTrue(self.mixin._is_instance_of_type("hello", str))
-        self.assertFalse(self.mixin._is_instance_of_type("5", int))
-        self.assertFalse(self.mixin._is_instance_of_type(5, str))
+        self.assertTrue(is_instance_of_type(5, int))
+        self.assertTrue(is_instance_of_type(3.14, float))
+        self.assertTrue(is_instance_of_type("hello", str))
+        self.assertFalse(is_instance_of_type("5", int))
+        self.assertFalse(is_instance_of_type(5, str))
 
     def test_list_of_int(self) -> None:
-        self.assertTrue(self.mixin._is_instance_of_type([1, 2, 3], list[int]))
-        self.assertFalse(self.mixin._is_instance_of_type([1, "2", 3], list[int]))
-        self.assertTrue(self.mixin._is_instance_of_type([], list[int]))  # empty list is valid
+        self.assertTrue(is_instance_of_type([1, 2, 3], list[int]))
+        self.assertFalse(is_instance_of_type([1, "2", 3], list[int]))
+        self.assertTrue(is_instance_of_type([], list[int]))  # empty list is valid
 
     def test_union_type(self) -> None:
         T = int | str
-        self.assertTrue(self.mixin._is_instance_of_type(5, T))
-        self.assertTrue(self.mixin._is_instance_of_type("hello", T))
-        self.assertFalse(self.mixin._is_instance_of_type(3.14, T))
+        self.assertTrue(is_instance_of_type(5, T))
+        self.assertTrue(is_instance_of_type("hello", T))
+        self.assertFalse(is_instance_of_type(3.14, T))
 
     def test_list_of_union(self) -> None:
         T = list[int | str]
-        self.assertTrue(self.mixin._is_instance_of_type([1, "a", 2], T))
-        self.assertFalse(self.mixin._is_instance_of_type([1, 2.0], T))
+        self.assertTrue(is_instance_of_type([1, "a", 2], T))
+        self.assertFalse(is_instance_of_type([1, 2.0], T))
 
     def test_or_operator(self) -> None:
         T = int | str
-        self.assertTrue(self.mixin._is_instance_of_type(5, T))
-        self.assertTrue(self.mixin._is_instance_of_type("hello", T))
-        self.assertFalse(self.mixin._is_instance_of_type(3.14, T))
+        self.assertTrue(is_instance_of_type(5, T))
+        self.assertTrue(is_instance_of_type("hello", T))
+        self.assertFalse(is_instance_of_type(3.14, T))
 
         T_list = list[int | str]
-        self.assertTrue(self.mixin._is_instance_of_type([1, "a", 2], T_list))
-        self.assertFalse(self.mixin._is_instance_of_type([1, 2.0], T_list))
+        self.assertTrue(is_instance_of_type([1, "a", 2], T_list))
+        self.assertFalse(is_instance_of_type([1, 2.0], T_list))
 
     def test_list_or_element(self) -> None:
         T = int | list[int]
-        self.assertTrue(self.mixin._is_instance_of_type(5, T))
-        self.assertTrue(self.mixin._is_instance_of_type([1, 2, 3], T))
-        self.assertFalse(self.mixin._is_instance_of_type("hello", T))
-        self.assertFalse(self.mixin._is_instance_of_type([1, "2"], T))
+        self.assertTrue(is_instance_of_type(5, T))
+        self.assertTrue(is_instance_of_type([1, 2, 3], T))
+        self.assertFalse(is_instance_of_type("hello", T))
+        self.assertFalse(is_instance_of_type([1, "2"], T))
 
     def test_not_implemented_for_dict(self) -> None:
         with self.assertRaises(NotImplementedError):
-            self.mixin._is_instance_of_type({"a": 1}, dict[str, int])
+            is_instance_of_type({"a": 1}, dict[str, int])
 
 
 class TestBehaviourWithPorts(unittest.TestCase):
@@ -264,6 +263,165 @@ class TestBehaviourWithPorts(unittest.TestCase):
 
         prod._set_output("output", "wired")
         self.assertEqual(cons.get_input("input"), "wired")
+
+
+class _DefaultingConsumer(BehaviourWithPorts, register=False):
+    """Consumer whose input ports declare default values."""
+
+    @classmethod
+    def input_ports(cls) -> dict:
+        return {
+            "input": PortInformation(data_type=str, required=True, default_value="fallback"),
+            "items": PortInformation(data_type=list[int], required=False, default_value=[1, 2]),
+        }
+
+    @classmethod
+    def output_ports(cls) -> dict:
+        return {}
+
+    def update(self) -> py_trees.common.Status:
+        return py_trees.common.Status.SUCCESS
+
+
+class _DefaultingProducer(BehaviourWithPorts, register=False):
+    """Producer whose output ports declare default values."""
+
+    @classmethod
+    def input_ports(cls) -> dict:
+        return {}
+
+    @classmethod
+    def output_ports(cls) -> dict:
+        return {
+            "output": PortInformation(data_type=str, default_value="initial"),
+            "items": PortInformation(data_type=list[int], default_value=[1, 2]),
+        }
+
+    def update(self) -> py_trees.common.Status:
+        self._set_output("output", "produced")
+        return py_trees.common.Status.SUCCESS
+
+
+class TestPortDefaultValues(unittest.TestCase):
+    """Default values declared on an input port's PortInformation."""
+
+    def setUp(self) -> None:
+        """Reset the blackboard before each test."""
+        py_trees.blackboard.Blackboard.clear()
+
+    def test_declared_default_returned_when_no_data(self) -> None:
+        """An unwired port with a declared default resolves to that default."""
+        cons = _DefaultingConsumer("cons")
+        cons.setup_ports()
+        self.assertEqual(cons.get_input("input"), "fallback")
+        self.assertEqual(cons.get_input("items"), [1, 2])
+
+    def test_data_overrides_declared_default(self) -> None:
+        """Actual data on the port takes precedence over the declared default."""
+        cons = _DefaultingConsumer("cons")
+        cons.setup_ports(port_remappings={"input": "/shared"})
+        seed_blackboard_value("/shared", "ActualValue")
+        self.assertEqual(cons.get_input("input"), "ActualValue")
+
+    def test_declared_default_applies_to_wired_but_unwritten_port(self) -> None:
+        """A port wired to a key that nobody has written to yet still falls back to the default."""
+        cons = _DefaultingConsumer("cons")
+        cons.setup_ports(port_remappings={"input": "/shared"})
+        self.assertEqual(cons.get_input("input"), "fallback")
+
+    def test_argument_default_overrides_declared_default(self) -> None:
+        """An explicit default= argument wins over the one declared on the port."""
+        cons = _DefaultingConsumer("cons")
+        cons.setup_ports()
+        self.assertEqual(cons.get_input("input", default="call_site"), "call_site")
+
+    def test_mutable_default_is_not_shared(self) -> None:
+        """Mutating a returned container default must not corrupt the port declaration."""
+        cons = _DefaultingConsumer("cons")
+        cons.setup_ports()
+        items = cons.get_input("items")
+        items.append(3)
+        self.assertEqual(cons.get_input("items"), [1, 2])
+        self.assertEqual(_DefaultingConsumer.input_ports()["items"].default_value, [1, 2])
+
+    def test_port_without_default_still_raises(self) -> None:
+        """A port with no declared default and no data raises, as before."""
+        cons = Consumer("cons")
+        cons.setup_ports()
+        with self.assertRaises(NoDataAvailable):
+            cons.get_input("input")
+
+    def test_required_port_with_default_is_not_a_required_blackboard_key(self) -> None:
+        """A required port with a default is always satisfiable, so it is not required on the blackboard."""
+        cons = _DefaultingConsumer("cons")
+        cons.setup_ports()
+        cons.blackboard_client.verify_required_keys_exist()  # must not raise
+
+        # ... whereas a required port without a default is registered as required.
+        plain = Consumer("plain")
+        plain.setup_ports()
+        with self.assertRaises(KeyError):
+            plain.blackboard_client.verify_required_keys_exist()
+
+    def test_default_value_type_is_validated_at_declaration(self) -> None:
+        """A default value that does not match the declared type is rejected on construction."""
+        with self.assertRaises(TypeError):
+            PortInformation(data_type=int, default_value="5")
+        with self.assertRaises(TypeError):
+            PortInformation(data_type=list[int], default_value=["a"])
+        with self.assertRaises(TypeError):
+            PortInformation(data_type=int | str, default_value=3.14)
+
+    def test_default_value_accepts_generic_and_union_types(self) -> None:
+        """Defaults are validated with the same type checking used for port reads."""
+        self.assertEqual(PortInformation(data_type=list[int], default_value=[1, 2]).default_value, [1, 2])
+        self.assertEqual(PortInformation(data_type=int | str, default_value="a").default_value, "a")
+
+    def test_has_default(self) -> None:
+        """``has_default`` distinguishes a declared default from none at all."""
+        self.assertTrue(PortInformation(data_type=int, default_value=0).has_default)
+        self.assertFalse(PortInformation(data_type=int).has_default)
+
+    def test_output_default_is_seeded_at_setup(self) -> None:
+        """An output default is written to the blackboard, so readers see it before the node ticks."""
+        prod = _DefaultingProducer("prod")
+        prod.setup_ports(port_remappings={"output": "/shared"})
+        self.assertEqual(prod.get_last_output("output"), "initial")
+
+        # A node wired to that output reads the seeded value without the producer having ticked.
+        cons = Consumer("cons")
+        cons.setup_ports(port_remappings={"input": "/shared"})
+        self.assertEqual(cons.get_input("input"), "initial")
+
+    def test_output_default_is_overwritten_by_the_node(self) -> None:
+        """Whatever the node writes replaces the seeded default."""
+        prod = _DefaultingProducer("prod")
+        prod.setup_ports()
+        prod.tick_once()
+        self.assertEqual(prod.get_last_output("output"), "produced")
+
+    def test_reset_restores_the_output_default(self) -> None:
+        """Resetting an output port with a default seeds it again rather than leaving it empty."""
+        prod = _DefaultingProducer("prod")
+        prod.setup_ports()
+        prod.tick_once()
+        prod.reset_all_output_ports()
+        self.assertEqual(prod.get_last_output("output"), "initial")
+
+    def test_reset_still_clears_an_output_without_a_default(self) -> None:
+        """Ports with no declared default keep the existing reset semantics."""
+        prod = Producer("prod")
+        prod.setup_ports()
+        prod.tick_once()
+        prod.reset_all_output_ports()
+        self.assertFalse(prod.blackboard_client.exists("output"))
+
+    def test_seeded_output_default_is_not_shared(self) -> None:
+        """Mutating a seeded container default must not corrupt the port declaration."""
+        prod = _DefaultingProducer("prod")
+        prod.setup_ports()
+        prod.get_last_output("items").append(3)
+        self.assertEqual(_DefaultingProducer.output_ports()["items"].default_value, [1, 2])
 
 
 class _RegistryLeaf(BehaviourWithPorts, register=False):

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -20,7 +20,14 @@ from py_trees.ports import (
 )
 from py_trees.ports_utils import is_instance_of_type
 
-from .test_ports_helpers import Consumer, ConsumerProducer, Producer, seed_blackboard_value
+from .test_ports_helpers import (
+    Consumer,
+    ConsumerProducer,
+    DefaultingConsumer,
+    DefaultingProducer,
+    Producer,
+    seed_blackboard_value,
+)
 
 
 # TODO: Add more tests for PortsMixin methods as needed. There are also some tests that can be ported over from
@@ -265,43 +272,6 @@ class TestBehaviourWithPorts(unittest.TestCase):
         self.assertEqual(cons.get_input("input"), "wired")
 
 
-class _DefaultingConsumer(BehaviourWithPorts, register=False):
-    """Consumer whose input ports declare default values."""
-
-    @classmethod
-    def input_ports(cls) -> dict:
-        return {
-            "input": PortInformation(data_type=str, required=True, default_value="fallback"),
-            "items": PortInformation(data_type=list[int], required=False, default_value=[1, 2]),
-        }
-
-    @classmethod
-    def output_ports(cls) -> dict:
-        return {}
-
-    def update(self) -> py_trees.common.Status:
-        return py_trees.common.Status.SUCCESS
-
-
-class _DefaultingProducer(BehaviourWithPorts, register=False):
-    """Producer whose output ports declare default values."""
-
-    @classmethod
-    def input_ports(cls) -> dict:
-        return {}
-
-    @classmethod
-    def output_ports(cls) -> dict:
-        return {
-            "output": PortInformation(data_type=str, default_value="initial"),
-            "items": PortInformation(data_type=list[int], default_value=[1, 2]),
-        }
-
-    def update(self) -> py_trees.common.Status:
-        self._set_output("output", "produced")
-        return py_trees.common.Status.SUCCESS
-
-
 class TestPortDefaultValues(unittest.TestCase):
     """Default values declared on an input port's PortInformation."""
 
@@ -311,38 +281,38 @@ class TestPortDefaultValues(unittest.TestCase):
 
     def test_declared_default_returned_when_no_data(self) -> None:
         """An unwired port with a declared default resolves to that default."""
-        cons = _DefaultingConsumer("cons")
+        cons = DefaultingConsumer("cons")
         cons.setup_ports()
         self.assertEqual(cons.get_input("input"), "fallback")
         self.assertEqual(cons.get_input("items"), [1, 2])
 
     def test_data_overrides_declared_default(self) -> None:
         """Actual data on the port takes precedence over the declared default."""
-        cons = _DefaultingConsumer("cons")
+        cons = DefaultingConsumer("cons")
         cons.setup_ports(port_remappings={"input": "/shared"})
         seed_blackboard_value("/shared", "ActualValue")
         self.assertEqual(cons.get_input("input"), "ActualValue")
 
     def test_declared_default_applies_to_wired_but_unwritten_port(self) -> None:
         """A port wired to a key that nobody has written to yet still falls back to the default."""
-        cons = _DefaultingConsumer("cons")
+        cons = DefaultingConsumer("cons")
         cons.setup_ports(port_remappings={"input": "/shared"})
         self.assertEqual(cons.get_input("input"), "fallback")
 
     def test_argument_default_overrides_declared_default(self) -> None:
         """An explicit default= argument wins over the one declared on the port."""
-        cons = _DefaultingConsumer("cons")
+        cons = DefaultingConsumer("cons")
         cons.setup_ports()
         self.assertEqual(cons.get_input("input", default="call_site"), "call_site")
 
     def test_mutable_default_is_not_shared(self) -> None:
         """Mutating a returned container default must not corrupt the port declaration."""
-        cons = _DefaultingConsumer("cons")
+        cons = DefaultingConsumer("cons")
         cons.setup_ports()
         items = cons.get_input("items")
         items.append(3)
         self.assertEqual(cons.get_input("items"), [1, 2])
-        self.assertEqual(_DefaultingConsumer.input_ports()["items"].default_value, [1, 2])
+        self.assertEqual(DefaultingConsumer.input_ports()["items"].default_value, [1, 2])
 
     def test_port_without_default_still_raises(self) -> None:
         """A port with no declared default and no data raises, as before."""
@@ -353,7 +323,7 @@ class TestPortDefaultValues(unittest.TestCase):
 
     def test_required_port_with_default_is_not_a_required_blackboard_key(self) -> None:
         """A required port with a default is always satisfiable, so it is not required on the blackboard."""
-        cons = _DefaultingConsumer("cons")
+        cons = DefaultingConsumer("cons")
         cons.setup_ports()
         cons.blackboard_client.verify_required_keys_exist()  # must not raise
 
@@ -384,7 +354,7 @@ class TestPortDefaultValues(unittest.TestCase):
 
     def test_output_default_is_seeded_at_setup(self) -> None:
         """An output default is written to the blackboard, so readers see it before the node ticks."""
-        prod = _DefaultingProducer("prod")
+        prod = DefaultingProducer("prod")
         prod.setup_ports(port_remappings={"output": "/shared"})
         self.assertEqual(prod.get_last_output("output"), "initial")
 
@@ -395,14 +365,14 @@ class TestPortDefaultValues(unittest.TestCase):
 
     def test_output_default_is_overwritten_by_the_node(self) -> None:
         """Whatever the node writes replaces the seeded default."""
-        prod = _DefaultingProducer("prod")
+        prod = DefaultingProducer("prod")
         prod.setup_ports()
         prod.tick_once()
         self.assertEqual(prod.get_last_output("output"), "produced")
 
     def test_reset_restores_the_output_default(self) -> None:
         """Resetting an output port with a default seeds it again rather than leaving it empty."""
-        prod = _DefaultingProducer("prod")
+        prod = DefaultingProducer("prod")
         prod.setup_ports()
         prod.tick_once()
         prod.reset_all_output_ports()
@@ -418,10 +388,10 @@ class TestPortDefaultValues(unittest.TestCase):
 
     def test_seeded_output_default_is_not_shared(self) -> None:
         """Mutating a seeded container default must not corrupt the port declaration."""
-        prod = _DefaultingProducer("prod")
+        prod = DefaultingProducer("prod")
         prod.setup_ports()
         prod.get_last_output("items").append(3)
-        self.assertEqual(_DefaultingProducer.output_ports()["items"].default_value, [1, 2])
+        self.assertEqual(DefaultingProducer.output_ports()["items"].default_value, [1, 2])
 
 
 class _RegistryLeaf(BehaviourWithPorts, register=False):

--- a/tests/test_ports_helpers.py
+++ b/tests/test_ports_helpers.py
@@ -86,6 +86,47 @@ class FloatConsumer(BehaviourWithPorts):
         return self.get_input(self.INPUT_PORT)
 
 
+class DefaultingConsumer(BehaviourWithPorts):
+    """Consumer whose input ports declare default values."""
+
+    @classmethod
+    def input_ports(cls) -> dict:
+        return {
+            "input": PortInformation(data_type=str, required=True, default_value="fallback"),
+            "items": PortInformation(data_type=list[int], required=False, default_value=[1, 2]),
+        }
+
+    @classmethod
+    def output_ports(cls) -> dict:
+        return {}
+
+    def update(self) -> py_trees.common.Status:
+        return py_trees.common.Status.SUCCESS
+
+    @property
+    def consumed_value(self) -> Any:
+        return self.get_input("input")
+
+
+class DefaultingProducer(BehaviourWithPorts):
+    """Producer whose output ports declare default values."""
+
+    @classmethod
+    def input_ports(cls) -> dict:
+        return {}
+
+    @classmethod
+    def output_ports(cls) -> dict:
+        return {
+            "output": PortInformation(data_type=str, default_value="initial"),
+            "items": PortInformation(data_type=list[int], default_value=[1, 2]),
+        }
+
+    def update(self) -> py_trees.common.Status:
+        self._set_output("output", "produced")
+        return py_trees.common.Status.SUCCESS
+
+
 # ---------- Tiny direct-only leaves (no ports needed) ----------
 
 

--- a/tests/test_ports_xml_parser.py
+++ b/tests/test_ports_xml_parser.py
@@ -27,7 +27,7 @@ from py_trees.ports_utils import (
     strip_trailing_uuid4,
 )
 
-from .test_ports_helpers import Consumer, Producer
+from .test_ports_helpers import Consumer, DefaultingConsumer, Producer
 
 
 class StdoutLogger:
@@ -109,25 +109,6 @@ class EchoCtorArgsChild(EchoCtorArgs):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-
-class DefaultingConsumer(BehaviourWithPorts):
-    """Consumer whose input port declares a default value."""
-
-    @classmethod
-    def input_ports(cls) -> dict:
-        return {"input": PortInformation(data_type=str, required=True, default_value="fallback")}
-
-    @classmethod
-    def output_ports(cls) -> dict:
-        return {}
-
-    def update(self) -> py_trees.common.Status:
-        return py_trees.common.Status.SUCCESS
-
-    @property
-    def consumed_value(self) -> Any:
-        return self.get_input("input")
 
 
 @dataclass

--- a/tests/test_ports_xml_parser.py
+++ b/tests/test_ports_xml_parser.py
@@ -111,6 +111,25 @@ class EchoCtorArgsChild(EchoCtorArgs):
         super().__init__(**kwargs)
 
 
+class DefaultingConsumer(BehaviourWithPorts):
+    """Consumer whose input port declares a default value."""
+
+    @classmethod
+    def input_ports(cls) -> dict:
+        return {"input": PortInformation(data_type=str, required=True, default_value="fallback")}
+
+    @classmethod
+    def output_ports(cls) -> dict:
+        return {}
+
+    def update(self) -> py_trees.common.Status:
+        return py_trees.common.Status.SUCCESS
+
+    @property
+    def consumed_value(self) -> Any:
+        return self.get_input("input")
+
+
 @dataclass
 class RobotData:
     type: str
@@ -324,6 +343,40 @@ class TestXMLParser(unittest.TestCase):
 
         self.assertEqual(type(node.consumed_value), str)
         self.assertEqual(node.consumed_value, "ABC")
+
+    def test_port_default_values_from_XML(self) -> None:
+        """An unwired port falls back to its declared default; a direct value in the XML overrides it."""
+        self.xml = """<root main_tree_to_execute="MainTree">
+        <BehaviorTree ID="MainTree">
+          <Sequence>
+            <DefaultingConsumer name="defaulted" />
+            <DefaultingConsumer name="overridden" input="explicit" />
+            <DefaultingConsumer name="wired" input="{unwritten}" />
+          </Sequence>
+        </BehaviorTree>
+        </root>"""
+
+        self.tempfile = tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".xml")
+        self.tempfile.write(self.xml)
+        self.tempfile.close()
+
+        root_node = parse_behaviour_tree_xml(self.tempfile.name, logger=StdoutLogger())
+        py_trees.trees.BehaviourTree(root_node).tick()
+
+        # No attribute at all: the declared default is used.
+        node = find_node_by_name(root_node, "defaulted", strip_prefix=True)
+        assert isinstance(node, DefaultingConsumer)
+        self.assertEqual(node.consumed_value, "fallback")
+
+        # A direct (constant) value in the XML overrides the default.
+        node = find_node_by_name(root_node, "overridden", strip_prefix=True)
+        assert isinstance(node, DefaultingConsumer)
+        self.assertEqual(node.consumed_value, "explicit")
+
+        # Wired to a key that nothing has written to yet: the default still applies.
+        node = find_node_by_name(root_node, "wired", strip_prefix=True)
+        assert isinstance(node, DefaultingConsumer)
+        self.assertEqual(node.consumed_value, "fallback")
 
     def test_parsing_direct_values_to_XML(self) -> None:
         """Verify that direct values are successfully parsed via the XML parser."""


### PR DESCRIPTION
Adds a `default_value` attribute to the `PortInformation` dataclass, which is a convenient extension that allows specifying default input/output port values right in the port declarations.

Closes https://github.com/splintered-reality/py_trees/issues/489