### PR TITLE
[ports] Do not raise error if a port value starts with a `/`

### DIFF
--- a/py_trees/parsers/behaviour_tree_xml.py
+++ b/py_trees/parsers/behaviour_tree_xml.py
@@ -229,11 +229,8 @@ def resolve_direct_value_remapping(key: str, remapping_table: dict[str, str]) ->
         The resolved value from the remapping table.
 
     Raises:
-        ValueError: If the prefixed key is not found in the remapping table or is of invalid format.
+        ValueError: If the prefixed key is not found in the remapping table.
     """
-    if key.startswith("/"):
-        raise ValueError(f"Key '{key}' is of invalid format")
-
     encoded_key = key.replace(".", DOT_REPLACEMENT)
     key = f"{CONST_PREFIX}{encoded_key}"
 


### PR DESCRIPTION
We should permit string values starting with slash just fine, for example a topic name?